### PR TITLE
feat(hub): create pulsive-hub crate for MVCC orchestration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1170,6 +1170,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "pulsive-hub"
+version = "0.1.0"
+dependencies = [
+ "pulsive-core",
+ "serde",
+ "thiserror 2.0.17",
+]
+
+[[package]]
 name = "pulsive-journal"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,7 @@
 [workspace]
 members = [
     "crates/pulsive-core",
+    "crates/pulsive-hub",
     "crates/pulsive-db",
     "crates/pulsive-script",
     "crates/pulsive-godot",
@@ -22,6 +23,7 @@ repository = "https://github.com/user/pulsive"
 [workspace.dependencies]
 # Internal crates
 pulsive-core = { path = "crates/pulsive-core" }
+pulsive-hub = { path = "crates/pulsive-hub" }
 pulsive-db = { path = "crates/pulsive-db" }
 pulsive-script = { path = "crates/pulsive-script" }
 pulsive-godot = { path = "crates/pulsive-godot" }

--- a/crates/pulsive-hub/Cargo.toml
+++ b/crates/pulsive-hub/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "pulsive-hub"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+description = "MVCC orchestrator for parallel execution of pulsive-core instances"
+
+[features]
+default = []
+
+[dependencies]
+pulsive-core = { workspace = true }
+serde = { workspace = true }
+thiserror = { workspace = true }
+
+[dev-dependencies]
+

--- a/crates/pulsive-hub/src/core.rs
+++ b/crates/pulsive-hub/src/core.rs
@@ -1,0 +1,152 @@
+//! Core - Thin wrapper around pulsive-core's Runtime + Model
+//!
+//! This is a **convenience wrapper only**. It bundles:
+//! - `pulsive_core::Runtime` (unchanged, used as-is)
+//! - `pulsive_core::Model` (unchanged, used as-is)
+//! - A `CoreId` for identification within a group
+//! - An RNG seed for deterministic parallel execution
+//!
+//! pulsive-core does NOT know about pulsive-hub. This wrapper simply
+//! provides a convenient way for CoreGroup to manage multiple Runtime+Model
+//! pairs. All actual simulation logic lives in pulsive-core.
+
+use pulsive_core::{Model, Rng, Runtime, UpdateResult};
+use serde::{Deserialize, Serialize};
+
+/// Unique identifier for a core within a group
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub struct CoreId(pub usize);
+
+impl std::fmt::Display for CoreId {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "Core({})", self.0)
+    }
+}
+
+/// Thin wrapper bundling a pulsive-core Runtime + Model
+///
+/// This is NOT a fork or modification of pulsive-core. It simply holds:
+/// - `runtime`: pulsive-core's Runtime, used exactly as-is
+/// - `model`: pulsive-core's Model, used exactly as-is
+/// - `id`: identifier for this instance within a CoreGroup
+/// - `rng_seed`: seed for deterministic RNG per core
+///
+/// The `tick()` method delegates directly to `runtime.tick(&mut model)`.
+pub struct Core {
+    /// Identifier within a CoreGroup
+    pub id: CoreId,
+    /// pulsive-core Runtime (used as-is, no modifications)
+    pub runtime: Runtime,
+    /// pulsive-core Model (used as-is, no modifications)
+    pub model: Model,
+    /// Seed for deterministic per-core RNG
+    rng_seed: u64,
+}
+
+impl Core {
+    /// Create a new core with the given runtime and RNG seed
+    pub fn new(id: CoreId, runtime: Runtime, seed: u64) -> Self {
+        Self {
+            id,
+            runtime,
+            model: Model::new(),
+            rng_seed: seed,
+        }
+    }
+
+    /// Create a core with default runtime
+    pub fn with_seed(id: CoreId, seed: u64) -> Self {
+        Self::new(id, Runtime::new(), seed)
+    }
+
+    /// Get the runtime (for registering handlers)
+    pub fn runtime(&self) -> &Runtime {
+        &self.runtime
+    }
+
+    /// Get mutable runtime (for registering handlers)
+    pub fn runtime_mut(&mut self) -> &mut Runtime {
+        &mut self.runtime
+    }
+
+    /// Get the local model
+    pub fn model(&self) -> &Model {
+        &self.model
+    }
+
+    /// Load a model snapshot into this core's local model
+    pub fn load_model(&mut self, model: Model) {
+        self.model = model;
+        // Reset RNG with seed + current tick for determinism
+        let tick = self.model.current_tick();
+        self.model.rng = Rng::new(hash_seed(self.rng_seed, self.id.0 as u64, tick));
+    }
+
+    /// Execute one tick - delegates directly to `runtime.tick(&mut model)`
+    pub fn tick(&mut self) -> UpdateResult {
+        self.runtime.tick(&mut self.model)
+    }
+
+    /// Get the current tick of the local model
+    pub fn current_tick(&self) -> u64 {
+        self.model.current_tick()
+    }
+
+    /// Re-seed the RNG for a new tick
+    pub fn reseed_rng(&mut self, tick: u64) {
+        self.model.rng = Rng::new(hash_seed(self.rng_seed, self.id.0 as u64, tick));
+    }
+}
+
+/// Hash function for deterministic RNG seeding
+///
+/// Combines base_seed, core_id, and tick to produce unique per-core-per-tick seeds
+fn hash_seed(base_seed: u64, core_id: u64, tick: u64) -> u64 {
+    // Simple but effective mixing function
+    let mut h = base_seed;
+    h = h.wrapping_mul(0x517cc1b727220a95);
+    h ^= core_id;
+    h = h.wrapping_mul(0x517cc1b727220a95);
+    h ^= tick;
+    h = h.wrapping_mul(0x517cc1b727220a95);
+    h
+}
+
+impl std::fmt::Debug for Core {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("Core")
+            .field("id", &self.id)
+            .field("tick", &self.model.current_tick())
+            .finish()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_core_creation() {
+        let core = Core::with_seed(CoreId(0), 12345);
+        assert_eq!(core.id, CoreId(0));
+        assert_eq!(core.current_tick(), 0);
+    }
+
+    #[test]
+    fn test_core_tick() {
+        let mut core = Core::with_seed(CoreId(0), 12345);
+        core.tick();
+        assert_eq!(core.current_tick(), 1);
+    }
+
+    #[test]
+    fn test_hash_seed_determinism() {
+        // Same inputs should produce same output
+        assert_eq!(hash_seed(100, 0, 5), hash_seed(100, 0, 5));
+
+        // Different inputs should produce different outputs
+        assert_ne!(hash_seed(100, 0, 5), hash_seed(100, 1, 5));
+        assert_ne!(hash_seed(100, 0, 5), hash_seed(100, 0, 6));
+        assert_ne!(hash_seed(100, 0, 5), hash_seed(101, 0, 5));
+    }
+}

--- a/crates/pulsive-hub/src/error.rs
+++ b/crates/pulsive-hub/src/error.rs
@@ -1,0 +1,22 @@
+//! Error types for pulsive-hub
+
+use thiserror::Error;
+
+/// Result type for pulsive-hub operations
+pub type Result<T> = std::result::Result<T, Error>;
+
+/// Errors that can occur in pulsive-hub
+#[derive(Debug, Error)]
+pub enum Error {
+    /// No groups registered in the hub
+    #[error("no core groups registered in hub")]
+    NoGroups,
+
+    /// Group not found
+    #[error("group {0:?} not found")]
+    GroupNotFound(crate::GroupId),
+
+    /// Core error
+    #[error("core error: {0}")]
+    Core(#[from] pulsive_core::Error),
+}

--- a/crates/pulsive-hub/src/group.rs
+++ b/crates/pulsive-hub/src/group.rs
@@ -1,0 +1,59 @@
+//! CoreGroup trait - The abstraction layer between Hub and Cores
+//!
+//! Hub only interacts with CoreGroup, never with individual Cores.
+//! This allows different execution strategies to be implemented.
+
+use pulsive_core::{Model, UpdateResult};
+use serde::{Deserialize, Serialize};
+
+/// Unique identifier for a core group
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub struct GroupId(pub usize);
+
+impl std::fmt::Display for GroupId {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "Group({})", self.0)
+    }
+}
+
+/// Trait for groups of cores with different execution strategies
+///
+/// Hub interacts only with this trait, never with individual Cores.
+/// This enables different execution models:
+/// - TickSyncGroup: All cores synchronized at same tick
+/// - (Future) AsyncGroup: Cores at different ticks
+/// - (Future) PipelineGroup: Streaming execution
+pub trait CoreGroup: Send {
+    /// Get the unique identifier for this group
+    fn id(&self) -> GroupId;
+
+    /// Get the current tick for this group
+    fn tick(&self) -> u64;
+
+    /// Get the number of cores in this group
+    fn core_count(&self) -> usize;
+
+    /// Load a model into all cores in this group
+    ///
+    /// Each core gets a clone of the model to work with locally.
+    fn load_model(&mut self, model: &Model);
+
+    /// Execute one tick on all cores
+    ///
+    /// The group decides the execution strategy:
+    /// - Serial (single core)
+    /// - Parallel with barrier sync
+    /// - etc.
+    ///
+    /// Returns combined results from all cores.
+    fn execute_tick(&mut self) -> Vec<UpdateResult>;
+
+    /// Extract the modified models from all cores
+    ///
+    /// After execute_tick, call this to get the mutated models
+    /// which can be diffed against the original to produce WriteSets.
+    fn extract_models(&self) -> Vec<&Model>;
+
+    /// Advance the tick counter for this group
+    fn advance_tick(&mut self);
+}

--- a/crates/pulsive-hub/src/hub.rs
+++ b/crates/pulsive-hub/src/hub.rs
@@ -1,0 +1,230 @@
+//! Hub - Central coordinator for parallel execution
+//!
+//! Hub owns the global model and coordinates CoreGroups.
+//! It never interacts with individual Cores directly.
+
+use crate::error::{Error, Result};
+use crate::group::{CoreGroup, GroupId};
+use crate::snapshot::ModelSnapshot;
+use crate::tick_sync::TickSyncGroup;
+use pulsive_core::{Model, UpdateResult};
+
+/// Result of a hub tick
+#[derive(Debug, Clone)]
+pub struct TickResult {
+    /// The tick that was executed
+    pub tick: u64,
+    /// Combined update results from all groups
+    pub updates: Vec<UpdateResult>,
+}
+
+/// Central coordinator that owns the global model and manages CoreGroups
+///
+/// Hub responsibilities:
+/// - Own and manage the global model
+/// - Create snapshots for groups
+/// - Merge changes from groups back to global model
+/// - (Future) Handle journal integration
+/// - (Future) Handle rollback requests
+pub struct Hub {
+    /// The global model (source of truth)
+    model: Model,
+    /// Core groups (Hub owns these, never individual cores)
+    groups: Vec<Box<dyn CoreGroup>>,
+    /// Version counter for MVCC
+    version: u64,
+}
+
+impl Hub {
+    /// Create a new hub with an empty model
+    pub fn new() -> Self {
+        Self {
+            model: Model::new(),
+            groups: Vec::new(),
+            version: 0,
+        }
+    }
+
+    /// Create a hub with an initial model
+    pub fn with_model(model: Model) -> Self {
+        Self {
+            model,
+            groups: Vec::new(),
+            version: 0,
+        }
+    }
+
+    /// Create a hub with a default single-core group
+    pub fn with_default_group(model: Model, seed: u64) -> Self {
+        let mut hub = Self::with_model(model);
+        hub.add_group(TickSyncGroup::single(GroupId(0), seed));
+        hub
+    }
+
+    /// Add a core group to the hub
+    pub fn add_group(&mut self, group: impl CoreGroup + 'static) {
+        self.groups.push(Box::new(group));
+    }
+
+    /// Get the number of groups
+    pub fn group_count(&self) -> usize {
+        self.groups.len()
+    }
+
+    /// Get a reference to the global model
+    pub fn model(&self) -> &Model {
+        &self.model
+    }
+
+    /// Get a mutable reference to the global model
+    pub fn model_mut(&mut self) -> &mut Model {
+        &mut self.model
+    }
+
+    /// Get the current version
+    pub fn version(&self) -> u64 {
+        self.version
+    }
+
+    /// Create a snapshot of the current model state
+    pub fn snapshot(&self) -> ModelSnapshot {
+        ModelSnapshot::new(&self.model, self.version)
+    }
+
+    /// Execute one tick across all groups
+    ///
+    /// Flow:
+    /// 1. Create snapshot of global model
+    /// 2. Load snapshot into each group's cores
+    /// 3. Execute tick on all groups
+    /// 4. Merge results back to global model
+    /// 5. Advance version
+    pub fn tick(&mut self) -> Result<TickResult> {
+        if self.groups.is_empty() {
+            return Err(Error::NoGroups);
+        }
+
+        let mut all_updates = Vec::new();
+
+        // For each group
+        for group in &mut self.groups {
+            // 1. Load current model into group's cores
+            group.load_model(&self.model);
+
+            // 2. Execute tick (group handles its cores)
+            let updates = group.execute_tick();
+            all_updates.extend(updates);
+
+            // 3. Extract the modified model from the group
+            // For now, with single group, just take the first core's model
+            let models = group.extract_models();
+            if let Some(modified_model) = models.first() {
+                // Update global model with the modified state
+                // This is a simple approach - future versions could diff and merge
+                self.model = (*modified_model).clone();
+            }
+
+            // 4. Advance group tick
+            group.advance_tick();
+        }
+
+        // 5. Advance version
+        self.version += 1;
+
+        Ok(TickResult {
+            tick: self.model.current_tick(),
+            updates: all_updates,
+        })
+    }
+
+    /// Get the current tick from the global model
+    pub fn current_tick(&self) -> u64 {
+        self.model.current_tick()
+    }
+}
+
+impl Default for Hub {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl std::fmt::Debug for Hub {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("Hub")
+            .field("tick", &self.model.current_tick())
+            .field("version", &self.version)
+            .field("groups", &self.groups.len())
+            .finish()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use pulsive_core::{DefId, Effect, Expr, TickHandler};
+
+    #[test]
+    fn test_hub_creation() {
+        let hub = Hub::new();
+        assert_eq!(hub.current_tick(), 0);
+        assert_eq!(hub.group_count(), 0);
+    }
+
+    #[test]
+    fn test_hub_with_default_group() {
+        let hub = Hub::with_default_group(Model::new(), 12345);
+        assert_eq!(hub.group_count(), 1);
+    }
+
+    #[test]
+    fn test_hub_tick_no_groups() {
+        let mut hub = Hub::new();
+        let result = hub.tick();
+        assert!(matches!(result, Err(Error::NoGroups)));
+    }
+
+    #[test]
+    fn test_hub_tick() {
+        let mut hub = Hub::with_default_group(Model::new(), 12345);
+
+        // Run a tick
+        let result = hub.tick();
+        assert!(result.is_ok());
+
+        let tick_result = result.unwrap();
+        assert_eq!(tick_result.tick, 1);
+    }
+
+    #[test]
+    fn test_hub_tick_with_handler() {
+        let model = Model::new();
+        let mut group = TickSyncGroup::single(GroupId(0), 12345);
+
+        // Register a tick handler that increments a global counter
+        group.on_tick(TickHandler {
+            id: DefId::new("counter"),
+            condition: None,
+            target_kind: None,
+            effects: vec![Effect::ModifyGlobal {
+                property: "count".to_string(),
+                op: pulsive_core::effect::ModifyOp::Add,
+                value: Expr::lit(1.0),
+            }],
+            priority: 0,
+        });
+
+        let mut hub = Hub::with_model(model);
+        hub.model_mut().set_global("count", 0.0f64);
+        hub.add_group(group);
+
+        // Run 3 ticks
+        hub.tick().unwrap();
+        hub.tick().unwrap();
+        hub.tick().unwrap();
+
+        // Check counter
+        let count = hub.model().get_global("count").and_then(|v| v.as_float());
+        assert_eq!(count, Some(3.0));
+    }
+}

--- a/crates/pulsive-hub/src/lib.rs
+++ b/crates/pulsive-hub/src/lib.rs
@@ -1,0 +1,44 @@
+//! Pulsive Hub - MVCC Orchestrator for Parallel Execution
+//!
+//! This crate provides the coordination layer for running multiple pulsive-core
+//! instances in parallel with MVCC-style snapshot isolation.
+//!
+//! ## Architecture
+//!
+//! ```text
+//! Hub (owns global model)
+//!  │
+//!  ├── CoreGroup (trait) ← Hub only interacts with this
+//!  │    │
+//!  │    └── Core[] ← Hidden from Hub
+//!  │         └── Runtime + Local Model
+//!  │
+//!  └── Global Model + Journal
+//! ```
+//!
+//! ## Key Components
+//!
+//! - [`Hub`]: Central coordinator that owns the global model
+//! - [`CoreGroup`]: Trait for groups of cores with different execution strategies
+//! - [`TickSyncGroup`]: Implementation where all cores stay at the same tick
+//! - [`Core`]: Thin wrapper bundling pulsive-core's Runtime + Model
+//!
+//! ## Design Principles
+//!
+//! 1. **Hub never touches Cores directly** - only through CoreGroup trait
+//! 2. **pulsive-core is standalone** - it does NOT know about pulsive-hub
+//! 3. **Core is just a wrapper** - bundles Runtime+Model, delegates all logic to pulsive-core
+
+mod core;
+mod error;
+mod group;
+mod hub;
+mod snapshot;
+mod tick_sync;
+
+pub use core::{Core, CoreId};
+pub use error::{Error, Result};
+pub use group::{CoreGroup, GroupId};
+pub use hub::Hub;
+pub use snapshot::ModelSnapshot;
+pub use tick_sync::TickSyncGroup;

--- a/crates/pulsive-hub/src/snapshot.rs
+++ b/crates/pulsive-hub/src/snapshot.rs
@@ -1,0 +1,56 @@
+//! ModelSnapshot - Immutable view of the model for parallel reads
+//!
+//! Currently a simple wrapper around Model::clone().
+//! Future optimizations could use:
+//! - Arc sharing for unchanged data
+//! - Copy-on-write for entities
+//! - Structural sharing
+
+use pulsive_core::Model;
+
+/// An immutable snapshot of the model at a point in time
+///
+/// Used to provide consistent read access to cores during parallel execution.
+/// Each core receives a snapshot and can read from it without synchronization.
+#[derive(Debug, Clone)]
+pub struct ModelSnapshot {
+    /// The model state at snapshot time
+    model: Model,
+    /// The tick when this snapshot was taken
+    tick: u64,
+    /// Version number (for MVCC)
+    version: u64,
+}
+
+impl ModelSnapshot {
+    /// Create a new snapshot from a model
+    pub fn new(model: &Model, version: u64) -> Self {
+        Self {
+            tick: model.current_tick(),
+            model: model.clone(),
+            version,
+        }
+    }
+
+    /// Get the tick this snapshot was taken at
+    pub fn tick(&self) -> u64 {
+        self.tick
+    }
+
+    /// Get the version number
+    pub fn version(&self) -> u64 {
+        self.version
+    }
+
+    /// Convert to an owned Model for a core to use
+    ///
+    /// Each core gets its own mutable copy to work with.
+    pub fn to_model(&self) -> Model {
+        self.model.clone()
+    }
+
+    /// Get a reference to the underlying model (for reading)
+    pub fn model(&self) -> &Model {
+        &self.model
+    }
+}

--- a/crates/pulsive-hub/src/tick_sync.rs
+++ b/crates/pulsive-hub/src/tick_sync.rs
@@ -1,0 +1,210 @@
+//! TickSyncGroup - All cores synchronized at the same tick
+//!
+//! This is the primary execution model where:
+//! - All cores process the same tick
+//! - Barrier synchronization ensures all complete before advancing
+//! - Single-core mode has zero parallel overhead
+
+use crate::core::{Core, CoreId};
+use crate::group::{CoreGroup, GroupId};
+use pulsive_core::{Model, Runtime, UpdateResult};
+
+/// A group where all cores stay synchronized at the same tick
+///
+/// Execution flow:
+/// 1. All cores load the same snapshot
+/// 2. All cores execute tick (parallel if multiple cores)
+/// 3. Barrier: wait for all cores to complete
+/// 4. Advance tick
+pub struct TickSyncGroup {
+    /// Unique identifier for this group
+    id: GroupId,
+    /// Current tick (all cores are at this tick)
+    tick: u64,
+    /// Cores owned by this group
+    cores: Vec<Core>,
+    /// Base seed for RNG
+    base_seed: u64,
+}
+
+impl TickSyncGroup {
+    /// Create a new group with the given cores
+    pub fn new(id: GroupId, cores: Vec<Core>, base_seed: u64) -> Self {
+        Self {
+            id,
+            tick: 0,
+            cores,
+            base_seed,
+        }
+    }
+
+    /// Create a group with N cores using default runtime
+    pub fn with_core_count(id: GroupId, count: usize, base_seed: u64) -> Self {
+        let cores = (0..count)
+            .map(|i| {
+                let core_id = CoreId(i);
+                let seed = hash_seed(base_seed, i as u64, 0);
+                Core::with_seed(core_id, seed)
+            })
+            .collect();
+
+        Self::new(id, cores, base_seed)
+    }
+
+    /// Create a single-core group (simplest case)
+    pub fn single(id: GroupId, seed: u64) -> Self {
+        Self::with_core_count(id, 1, seed)
+    }
+
+    /// Add a core to this group
+    pub fn add_core(&mut self, core: Core) {
+        self.cores.push(core);
+    }
+
+    /// Get a reference to the cores (for registering handlers)
+    pub fn cores(&self) -> &[Core] {
+        &self.cores
+    }
+
+    /// Get mutable reference to the cores (for registering handlers)
+    pub fn cores_mut(&mut self) -> &mut [Core] {
+        &mut self.cores
+    }
+
+    /// Register an event handler on all cores
+    pub fn on_event(&mut self, handler: pulsive_core::EventHandler) {
+        for core in &mut self.cores {
+            core.runtime_mut().on_event(handler.clone());
+        }
+    }
+
+    /// Register a tick handler on all cores
+    pub fn on_tick(&mut self, handler: pulsive_core::TickHandler) {
+        for core in &mut self.cores {
+            core.runtime_mut().on_tick(handler.clone());
+        }
+    }
+
+    /// Create a TickSyncGroup from an existing runtime
+    ///
+    /// This is useful when you want to reuse a configured runtime.
+    pub fn from_runtime(id: GroupId, runtime: Runtime, seed: u64) -> Self {
+        let core = Core::new(CoreId(0), runtime, seed);
+        Self::new(id, vec![core], seed)
+    }
+}
+
+impl CoreGroup for TickSyncGroup {
+    fn id(&self) -> GroupId {
+        self.id
+    }
+
+    fn tick(&self) -> u64 {
+        self.tick
+    }
+
+    fn core_count(&self) -> usize {
+        self.cores.len()
+    }
+
+    fn load_model(&mut self, model: &Model) {
+        for core in &mut self.cores {
+            core.load_model(model.clone());
+        }
+    }
+
+    fn execute_tick(&mut self) -> Vec<UpdateResult> {
+        if self.cores.len() == 1 {
+            // Single core - direct execution, no overhead
+            let result = self.cores[0].tick();
+            vec![result]
+        } else {
+            // Multiple cores - for now, execute serially
+            // TODO: Add parallel execution with rayon when needed
+            self.cores.iter_mut().map(|core| core.tick()).collect()
+        }
+    }
+
+    fn extract_models(&self) -> Vec<&Model> {
+        self.cores.iter().map(|core| core.model()).collect()
+    }
+
+    fn advance_tick(&mut self) {
+        self.tick += 1;
+        // Re-seed RNGs for determinism
+        for (i, core) in self.cores.iter_mut().enumerate() {
+            core.reseed_rng(self.tick);
+            // Also update the seed for the new tick
+            let new_seed = hash_seed(self.base_seed, i as u64, self.tick);
+            core.model.rng = pulsive_core::Rng::new(new_seed);
+        }
+    }
+}
+
+/// Hash function for deterministic RNG seeding
+fn hash_seed(base_seed: u64, core_id: u64, tick: u64) -> u64 {
+    let mut h = base_seed;
+    h = h.wrapping_mul(0x517cc1b727220a95);
+    h ^= core_id;
+    h = h.wrapping_mul(0x517cc1b727220a95);
+    h ^= tick;
+    h = h.wrapping_mul(0x517cc1b727220a95);
+    h
+}
+
+impl std::fmt::Debug for TickSyncGroup {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("TickSyncGroup")
+            .field("id", &self.id)
+            .field("tick", &self.tick)
+            .field("core_count", &self.cores.len())
+            .finish()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_single_core_group() {
+        let group = TickSyncGroup::single(GroupId(0), 12345);
+        assert_eq!(group.core_count(), 1);
+        assert_eq!(group.tick(), 0);
+    }
+
+    #[test]
+    fn test_multi_core_group() {
+        let group = TickSyncGroup::with_core_count(GroupId(0), 4, 12345);
+        assert_eq!(group.core_count(), 4);
+    }
+
+    #[test]
+    fn test_execute_tick() {
+        let mut group = TickSyncGroup::single(GroupId(0), 12345);
+
+        // Load empty model
+        let model = Model::new();
+        group.load_model(&model);
+
+        // Execute tick
+        let results = group.execute_tick();
+        assert_eq!(results.len(), 1);
+
+        // Check tick advanced in core's local model
+        let models = group.extract_models();
+        assert_eq!(models[0].current_tick(), 1);
+    }
+
+    #[test]
+    fn test_advance_tick() {
+        let mut group = TickSyncGroup::single(GroupId(0), 12345);
+        assert_eq!(group.tick(), 0);
+
+        group.advance_tick();
+        assert_eq!(group.tick(), 1);
+
+        group.advance_tick();
+        assert_eq!(group.tick(), 2);
+    }
+}


### PR DESCRIPTION
## Summary

Implements the MVCC Orchestrator architecture (RFC #21) with a new `pulsive-hub` crate.

## Architecture

```
Hub (owns global model)
 │
 ├── CoreGroup (trait) ← Hub only interacts with this
 │    │
 │    └── Core[] ← Hidden from Hub
 │         └── Runtime + Local Model
 │
 └── Global Model + Journal
```

## Key Components

| Component | Description |
|-----------|-------------|
| `Hub` | Central coordinator, owns global model, manages CoreGroups |
| `CoreGroup` (trait) | Abstraction for different execution strategies |
| `TickSyncGroup` | Implementation with tick-synchronized execution |
| `Core` | Wraps full pulsive-core Runtime + local Model |
| `ModelSnapshot` | Immutable view for consistent reads |

## Design Principles

1. **Hub never touches Cores directly** - only through CoreGroup trait
2. **Core = full Runtime** - reactive flow, views, events all preserved
3. **pulsive-core is UNCHANGED** - this crate wraps, doesn't modify
4. **Single-core mode has zero overhead** - no parallel infrastructure when core_count=1

## Usage

```rust
// Single-core (simplest)
let hub = Hub::with_default_group(Model::new(), 12345);

// Multi-core
let group = TickSyncGroup::with_core_count(GroupId(0), 4, 12345);
let mut hub = Hub::with_model(model);
hub.add_group(group);

// Run simulation
loop {
    hub.tick()?;
}
```

## Tests

12 new tests covering:
- Core creation and ticking
- CoreGroup trait implementation
- Hub lifecycle and tick execution
- Handler registration and execution through hub

## Related Issues

- RFC #21 (MVCC Orchestrator Architecture)
- Closes #22 (Create pulsive-hub crate)
