### PR TITLE
feat(core,hub): implement Phase 1 deferred writes for parallel execution

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1143,6 +1143,7 @@ name = "pulsive-core"
 version = "0.1.0"
 dependencies = [
  "indexmap",
+ "ron",
  "serde",
  "thiserror 2.0.17",
 ]

--- a/crates/pulsive-core/Cargo.toml
+++ b/crates/pulsive-core/Cargo.toml
@@ -13,3 +13,6 @@ journal = []  # Enable message recording and state snapshots for audit/replay/de
 serde = { workspace = true }
 thiserror = { workspace = true }
 indexmap = { workspace = true }
+
+[dev-dependencies]
+ron = { workspace = true }

--- a/crates/pulsive-core/src/lib.rs
+++ b/crates/pulsive-core/src/lib.rs
@@ -37,6 +37,7 @@ pub mod runtime;
 pub mod state_history;
 pub mod time;
 mod value;
+pub mod write_set;
 
 #[cfg(feature = "journal")]
 pub mod journal;
@@ -55,6 +56,7 @@ pub use runtime::{EventHandler, Runtime, TickHandler, UpdateResult};
 pub use state_history::{StateHistory, StateInterpolation};
 pub use time::{Clock, Speed, Tick, Timestamp};
 pub use value::{Value, ValueMap};
+pub use write_set::{PendingWrite, WriteSet, WriteSetResult};
 
 #[cfg(feature = "journal")]
 pub use journal::{Journal, JournalConfig, JournalEntry, JournalStats, Snapshot, SnapshotId};

--- a/crates/pulsive-core/src/write_set.rs
+++ b/crates/pulsive-core/src/write_set.rs
@@ -1,0 +1,285 @@
+//! Deferred write semantics for parallel execution support
+//!
+//! This module provides types for collecting pending writes during effect execution,
+//! enabling a clean separation of read/compute/write phases.
+//!
+//! # Overview
+//!
+//! Instead of mutating the `Model` directly during effect execution, handlers
+//! collect `PendingWrite` operations into a `WriteSet`. These writes are then
+//! applied atomically by `pulsive-hub` at the end of the tick.
+//!
+//! # Benefits
+//!
+//! - Clean separation of read/compute/write phases
+//! - Enables undo/replay by storing WriteSets
+//! - Foundation for parallel execution (handlers can run concurrently during read phase)
+//!
+//! # Architecture
+//!
+//! - `WriteSet` and `PendingWrite` types live in `pulsive-core`
+//! - `WriteSet::apply()` is implemented in `pulsive-hub` (where the Hub owns the Model)
+
+use crate::effect::ModifyOp;
+use crate::{DefId, EntityId, Value, ValueMap};
+use serde::{Deserialize, Serialize};
+
+/// A pending write operation to be applied to the model
+///
+/// Each variant represents a specific mutation that will be applied atomically.
+/// Values in these variants are already evaluated (no expressions).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub enum PendingWrite {
+    /// Set a property on an entity to a specific value
+    SetProperty {
+        /// The entity to modify
+        entity_id: EntityId,
+        /// The property key
+        key: String,
+        /// The value to set (already evaluated)
+        value: Value,
+    },
+
+    /// Modify a numeric property on an entity
+    ModifyProperty {
+        /// The entity to modify
+        entity_id: EntityId,
+        /// The property key
+        key: String,
+        /// The operation to apply
+        op: ModifyOp,
+        /// The operand value (already evaluated to f64)
+        value: f64,
+    },
+
+    /// Set a global property to a specific value
+    SetGlobal {
+        /// The property key
+        key: String,
+        /// The value to set (already evaluated)
+        value: Value,
+    },
+
+    /// Modify a global numeric property
+    ModifyGlobal {
+        /// The property key
+        key: String,
+        /// The operation to apply
+        op: ModifyOp,
+        /// The operand value (already evaluated to f64)
+        value: f64,
+    },
+
+    /// Add a flag to an entity
+    AddFlag {
+        /// The entity to modify
+        entity_id: EntityId,
+        /// The flag to add
+        flag: DefId,
+    },
+
+    /// Remove a flag from an entity
+    RemoveFlag {
+        /// The entity to modify
+        entity_id: EntityId,
+        /// The flag to remove
+        flag: DefId,
+    },
+
+    /// Spawn a new entity
+    SpawnEntity {
+        /// The kind of entity to create
+        kind: DefId,
+        /// Initial properties (already evaluated)
+        properties: ValueMap,
+    },
+
+    /// Destroy an entity
+    DestroyEntity {
+        /// The entity to destroy
+        id: EntityId,
+    },
+}
+
+/// Result of applying a WriteSet to a model
+#[derive(Debug, Clone, Default)]
+pub struct WriteSetResult {
+    /// Entity IDs that were spawned
+    pub spawned: Vec<EntityId>,
+    /// Entity IDs that were destroyed
+    pub destroyed: Vec<EntityId>,
+}
+
+impl WriteSetResult {
+    /// Create a new empty result
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Merge another result into this one
+    pub fn merge(&mut self, other: WriteSetResult) {
+        self.spawned.extend(other.spawned);
+        self.destroyed.extend(other.destroyed);
+    }
+}
+
+/// A collection of pending writes to be applied atomically
+///
+/// WriteSets are collected during effect execution and applied at the end of
+/// a tick by the Hub. This enables:
+/// - Deterministic parallel execution (each core produces a WriteSet)
+/// - Conflict detection (compare WriteSets before merging)
+/// - Journaling (store WriteSets for replay)
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct WriteSet {
+    /// The pending writes in order
+    writes: Vec<PendingWrite>,
+}
+
+impl WriteSet {
+    /// Create a new empty WriteSet
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Add a pending write to the set
+    pub fn push(&mut self, write: PendingWrite) {
+        self.writes.push(write);
+    }
+
+    /// Extend this WriteSet with writes from another
+    pub fn extend(&mut self, other: WriteSet) {
+        self.writes.extend(other.writes);
+    }
+
+    /// Get the number of pending writes
+    pub fn len(&self) -> usize {
+        self.writes.len()
+    }
+
+    /// Check if the WriteSet is empty
+    pub fn is_empty(&self) -> bool {
+        self.writes.is_empty()
+    }
+
+    /// Get an iterator over the pending writes
+    pub fn iter(&self) -> impl Iterator<Item = &PendingWrite> {
+        self.writes.iter()
+    }
+
+    /// Consume the WriteSet and return the underlying writes
+    pub fn into_writes(self) -> Vec<PendingWrite> {
+        self.writes
+    }
+
+    /// Get a reference to the underlying writes
+    pub fn writes(&self) -> &[PendingWrite] {
+        &self.writes
+    }
+
+    /// Clear all pending writes
+    pub fn clear(&mut self) {
+        self.writes.clear();
+    }
+
+    /// Merge multiple WriteSets into one
+    pub fn merge(write_sets: Vec<WriteSet>) -> WriteSet {
+        let mut merged = WriteSet::new();
+        for ws in write_sets {
+            merged.extend(ws);
+        }
+        merged
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_write_set_empty() {
+        let write_set = WriteSet::new();
+        assert!(write_set.is_empty());
+        assert_eq!(write_set.len(), 0);
+    }
+
+    #[test]
+    fn test_write_set_push() {
+        let mut write_set = WriteSet::new();
+        write_set.push(PendingWrite::SetGlobal {
+            key: "test".to_string(),
+            value: Value::Float(42.0),
+        });
+        assert_eq!(write_set.len(), 1);
+        assert!(!write_set.is_empty());
+    }
+
+    #[test]
+    fn test_write_set_extend() {
+        let mut write_set1 = WriteSet::new();
+        write_set1.push(PendingWrite::SetGlobal {
+            key: "a".to_string(),
+            value: Value::Float(1.0),
+        });
+
+        let mut write_set2 = WriteSet::new();
+        write_set2.push(PendingWrite::SetGlobal {
+            key: "b".to_string(),
+            value: Value::Float(2.0),
+        });
+
+        write_set1.extend(write_set2);
+        assert_eq!(write_set1.len(), 2);
+    }
+
+    #[test]
+    fn test_write_set_merge() {
+        let mut ws1 = WriteSet::new();
+        ws1.push(PendingWrite::SetGlobal {
+            key: "a".to_string(),
+            value: Value::Float(1.0),
+        });
+
+        let mut ws2 = WriteSet::new();
+        ws2.push(PendingWrite::SetGlobal {
+            key: "b".to_string(),
+            value: Value::Float(2.0),
+        });
+
+        let merged = WriteSet::merge(vec![ws1, ws2]);
+        assert_eq!(merged.len(), 2);
+    }
+
+    #[test]
+    fn test_write_set_serialization() {
+        let mut write_set = WriteSet::new();
+        write_set.push(PendingWrite::SetGlobal {
+            key: "gold".to_string(),
+            value: Value::Float(100.0),
+        });
+        write_set.push(PendingWrite::SpawnEntity {
+            kind: DefId::new("nation"),
+            properties: ValueMap::new(),
+        });
+
+        // Test that it can be serialized and deserialized using RON
+        let serialized = ron::to_string(&write_set).expect("serialize");
+        let deserialized: WriteSet = ron::from_str(&serialized).expect("deserialize");
+
+        assert_eq!(deserialized.len(), 2);
+    }
+
+    #[test]
+    fn test_write_set_result_merge() {
+        let mut result1 = WriteSetResult::new();
+        result1.spawned.push(EntityId(1));
+
+        let mut result2 = WriteSetResult::new();
+        result2.spawned.push(EntityId(2));
+        result2.destroyed.push(EntityId(3));
+
+        result1.merge(result2);
+        assert_eq!(result1.spawned.len(), 2);
+        assert_eq!(result1.destroyed.len(), 1);
+    }
+}

--- a/crates/pulsive-hub/src/commit.rs
+++ b/crates/pulsive-hub/src/commit.rs
@@ -1,0 +1,549 @@
+//! WriteSet application and commit functionality
+//!
+//! This module provides the `apply()` function for applying WriteSets to the Model.
+//! The Hub is responsible for applying writes - cores only collect them.
+//!
+//! # Design
+//!
+//! - `WriteSet` and `PendingWrite` types are defined in `pulsive-core`
+//! - `apply()` lives here in `pulsive-hub` because the Hub owns the Model
+//! - This separation enables conflict detection and resolution before applying
+
+use pulsive_core::{Model, PendingWrite, Value, WriteSet, WriteSetResult};
+
+/// Apply a WriteSet to a Model
+///
+/// This function applies all pending writes from a WriteSet atomically
+/// to the given model. The writes are applied in order.
+///
+/// # Arguments
+///
+/// * `write_set` - The WriteSet to apply
+/// * `model` - The Model to apply writes to
+///
+/// # Returns
+///
+/// A `WriteSetResult` containing:
+/// - `spawned`: Entity IDs that were created
+/// - `destroyed`: Entity IDs that were removed
+pub fn apply(write_set: &WriteSet, model: &mut Model) -> WriteSetResult {
+    let mut result = WriteSetResult::new();
+
+    for write in write_set.iter() {
+        match write {
+            PendingWrite::SetProperty {
+                entity_id,
+                key,
+                value,
+            } => {
+                if let Some(entity) = model.entities.get_mut(*entity_id) {
+                    entity.set(key.clone(), value.clone());
+                }
+            }
+
+            PendingWrite::ModifyProperty {
+                entity_id,
+                key,
+                op,
+                value,
+            } => {
+                if let Some(entity) = model.entities.get_mut(*entity_id) {
+                    let current = entity.get_number(key).unwrap_or(0.0);
+                    let new_value = op.apply(current, *value);
+                    entity.set(key.clone(), new_value);
+                }
+            }
+
+            PendingWrite::SetGlobal { key, value } => {
+                model.globals.insert(key.clone(), value.clone());
+            }
+
+            PendingWrite::ModifyGlobal { key, op, value } => {
+                let current = model
+                    .globals
+                    .get(key)
+                    .and_then(|v| v.as_float())
+                    .unwrap_or(0.0);
+                let new_value = op.apply(current, *value);
+                model.globals.insert(key.clone(), Value::Float(new_value));
+            }
+
+            PendingWrite::AddFlag { entity_id, flag } => {
+                if let Some(entity) = model.entities.get_mut(*entity_id) {
+                    entity.add_flag(flag.clone());
+                }
+            }
+
+            PendingWrite::RemoveFlag { entity_id, flag } => {
+                if let Some(entity) = model.entities.get_mut(*entity_id) {
+                    entity.remove_flag(flag);
+                }
+            }
+
+            PendingWrite::SpawnEntity { kind, properties } => {
+                let entity = model.entities.create(kind.clone());
+                let entity_id = entity.id;
+
+                // Set initial properties
+                for (key, value) in properties {
+                    entity.set(key.clone(), value.clone());
+                }
+
+                result.spawned.push(entity_id);
+            }
+
+            PendingWrite::DestroyEntity { id } => {
+                model.entities.remove(*id);
+                result.destroyed.push(*id);
+            }
+        }
+    }
+
+    result
+}
+
+/// Apply multiple WriteSets by merging them first
+///
+/// This is a convenience function for applying results from multiple cores.
+pub fn apply_batch(write_sets: Vec<WriteSet>, model: &mut Model) -> WriteSetResult {
+    let merged = WriteSet::merge(write_sets);
+    apply(&merged, model)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use pulsive_core::{DefId, ModifyOp, ValueMap};
+
+    #[test]
+    fn test_apply_set_global() {
+        let mut model = Model::new();
+        let mut write_set = WriteSet::new();
+
+        write_set.push(PendingWrite::SetGlobal {
+            key: "gold".to_string(),
+            value: Value::Float(100.0),
+        });
+
+        apply(&write_set, &mut model);
+
+        assert_eq!(
+            model.get_global("gold").and_then(|v| v.as_float()),
+            Some(100.0)
+        );
+    }
+
+    #[test]
+    fn test_apply_modify_global() {
+        let mut model = Model::new();
+        model.set_global("gold", 100.0f64);
+
+        let mut write_set = WriteSet::new();
+        write_set.push(PendingWrite::ModifyGlobal {
+            key: "gold".to_string(),
+            op: ModifyOp::Add,
+            value: 50.0,
+        });
+
+        apply(&write_set, &mut model);
+
+        assert_eq!(
+            model.get_global("gold").and_then(|v| v.as_float()),
+            Some(150.0)
+        );
+    }
+
+    #[test]
+    fn test_apply_entity_property() {
+        let mut model = Model::new();
+        let entity = model.entities.create("nation");
+        entity.set("gold", 100.0f64);
+        let entity_id = entity.id;
+
+        let mut write_set = WriteSet::new();
+        write_set.push(PendingWrite::SetProperty {
+            entity_id,
+            key: "gold".to_string(),
+            value: Value::Float(200.0),
+        });
+
+        apply(&write_set, &mut model);
+
+        assert_eq!(
+            model
+                .entities
+                .get(entity_id)
+                .and_then(|e| e.get_number("gold")),
+            Some(200.0)
+        );
+    }
+
+    #[test]
+    fn test_apply_modify_entity_property() {
+        let mut model = Model::new();
+        let entity = model.entities.create("nation");
+        entity.set("gold", 100.0f64);
+        let entity_id = entity.id;
+
+        let mut write_set = WriteSet::new();
+        write_set.push(PendingWrite::ModifyProperty {
+            entity_id,
+            key: "gold".to_string(),
+            op: ModifyOp::Mul,
+            value: 2.0,
+        });
+
+        apply(&write_set, &mut model);
+
+        assert_eq!(
+            model
+                .entities
+                .get(entity_id)
+                .and_then(|e| e.get_number("gold")),
+            Some(200.0)
+        );
+    }
+
+    #[test]
+    fn test_apply_spawn_entity() {
+        let mut model = Model::new();
+
+        let mut properties = ValueMap::new();
+        properties.insert("name".to_string(), Value::String("France".to_string()));
+        properties.insert("gold".to_string(), Value::Float(100.0));
+
+        let mut write_set = WriteSet::new();
+        write_set.push(PendingWrite::SpawnEntity {
+            kind: DefId::new("nation"),
+            properties,
+        });
+
+        let result = apply(&write_set, &mut model);
+
+        assert_eq!(result.spawned.len(), 1);
+        let entity_id = result.spawned[0];
+        let entity = model.entities.get(entity_id).unwrap();
+        assert_eq!(entity.get("name").and_then(|v| v.as_str()), Some("France"));
+        assert_eq!(entity.get_number("gold"), Some(100.0));
+    }
+
+    #[test]
+    fn test_apply_destroy_entity() {
+        let mut model = Model::new();
+        let entity = model.entities.create("nation");
+        let entity_id = entity.id;
+
+        assert!(model.entities.get(entity_id).is_some());
+
+        let mut write_set = WriteSet::new();
+        write_set.push(PendingWrite::DestroyEntity { id: entity_id });
+
+        let result = apply(&write_set, &mut model);
+
+        assert_eq!(result.destroyed.len(), 1);
+        assert!(model.entities.get(entity_id).is_none());
+    }
+
+    #[test]
+    fn test_apply_flags() {
+        let mut model = Model::new();
+        let entity = model.entities.create("nation");
+        let entity_id = entity.id;
+
+        let mut write_set = WriteSet::new();
+        write_set.push(PendingWrite::AddFlag {
+            entity_id,
+            flag: DefId::new("at_war"),
+        });
+
+        apply(&write_set, &mut model);
+
+        let entity = model.entities.get(entity_id).unwrap();
+        assert!(entity.has_flag(&DefId::new("at_war")));
+
+        // Remove the flag
+        let mut write_set = WriteSet::new();
+        write_set.push(PendingWrite::RemoveFlag {
+            entity_id,
+            flag: DefId::new("at_war"),
+        });
+
+        apply(&write_set, &mut model);
+
+        let entity = model.entities.get(entity_id).unwrap();
+        assert!(!entity.has_flag(&DefId::new("at_war")));
+    }
+
+    #[test]
+    fn test_atomic_application_order() {
+        // Verify that writes are applied in order
+        let mut model = Model::new();
+        model.set_global("counter", 0.0f64);
+
+        let mut write_set = WriteSet::new();
+        // First add 10
+        write_set.push(PendingWrite::ModifyGlobal {
+            key: "counter".to_string(),
+            op: ModifyOp::Add,
+            value: 10.0,
+        });
+        // Then multiply by 2
+        write_set.push(PendingWrite::ModifyGlobal {
+            key: "counter".to_string(),
+            op: ModifyOp::Mul,
+            value: 2.0,
+        });
+
+        apply(&write_set, &mut model);
+
+        // Should be (0 + 10) * 2 = 20
+        assert_eq!(
+            model.get_global("counter").and_then(|v| v.as_float()),
+            Some(20.0)
+        );
+    }
+
+    #[test]
+    fn test_apply_batch() {
+        let mut model = Model::new();
+        model.set_global("total", 0.0f64);
+
+        let mut ws1 = WriteSet::new();
+        ws1.push(PendingWrite::ModifyGlobal {
+            key: "total".to_string(),
+            op: ModifyOp::Add,
+            value: 10.0,
+        });
+
+        let mut ws2 = WriteSet::new();
+        ws2.push(PendingWrite::ModifyGlobal {
+            key: "total".to_string(),
+            op: ModifyOp::Add,
+            value: 20.0,
+        });
+
+        apply_batch(vec![ws1, ws2], &mut model);
+
+        assert_eq!(
+            model.get_global("total").and_then(|v| v.as_float()),
+            Some(30.0)
+        );
+    }
+
+    // ========================================================================
+    // Integration tests: collect_effect → apply pattern
+    // ========================================================================
+
+    use pulsive_core::{effect::EffectResult, Effect, EntityRef, Expr, Runtime};
+
+    /// Test the full deferred write pattern: collect_effect then apply
+    #[test]
+    fn test_collect_then_apply_global() {
+        let mut model = Model::new();
+        model.set_global("gold", 100.0f64);
+
+        let mut runtime = Runtime::new();
+        let mut effect_result = EffectResult::new();
+        let params = ValueMap::new();
+
+        // Create an effect that modifies a global
+        let effect = Effect::ModifyGlobal {
+            property: "gold".to_string(),
+            op: ModifyOp::Add,
+            value: Expr::lit(50.0),
+        };
+
+        // Phase 1: Collect writes (model not mutated yet)
+        let write_set = runtime.collect_effect(
+            &mut model,
+            &effect,
+            &EntityRef::Global,
+            &params,
+            &mut effect_result,
+        );
+
+        // Verify model wasn't mutated during collection
+        assert_eq!(
+            model.get_global("gold").and_then(|v| v.as_float()),
+            Some(100.0),
+            "Model should not be mutated during collect phase"
+        );
+
+        // Verify we collected the write
+        assert_eq!(write_set.len(), 1);
+
+        // Phase 2: Apply writes
+        apply(&write_set, &mut model);
+
+        // Now model should be updated
+        assert_eq!(
+            model.get_global("gold").and_then(|v| v.as_float()),
+            Some(150.0)
+        );
+    }
+
+    /// Test collect → apply for entity property modification
+    #[test]
+    fn test_collect_then_apply_entity() {
+        let mut model = Model::new();
+        let entity = model.entities.create("nation");
+        entity.set("population", 1000.0f64);
+        let entity_id = entity.id;
+
+        let mut runtime = Runtime::new();
+        let mut effect_result = EffectResult::new();
+        let params = ValueMap::new();
+
+        // Effect to double the population
+        let effect = Effect::ModifyProperty {
+            property: "population".to_string(),
+            op: ModifyOp::Mul,
+            value: Expr::lit(2.0),
+        };
+
+        let target = EntityRef::Entity(entity_id);
+
+        // Collect
+        let write_set =
+            runtime.collect_effect(&mut model, &effect, &target, &params, &mut effect_result);
+
+        // Verify not mutated
+        assert_eq!(
+            model
+                .entities
+                .get(entity_id)
+                .and_then(|e| e.get_number("population")),
+            Some(1000.0)
+        );
+
+        // Apply
+        apply(&write_set, &mut model);
+
+        assert_eq!(
+            model
+                .entities
+                .get(entity_id)
+                .and_then(|e| e.get_number("population")),
+            Some(2000.0)
+        );
+    }
+
+    /// Test collect → apply for a sequence of effects
+    #[test]
+    fn test_collect_sequence_then_apply() {
+        let mut model = Model::new();
+        model.set_global("counter", 0.0f64);
+
+        let mut runtime = Runtime::new();
+        let mut effect_result = EffectResult::new();
+        let params = ValueMap::new();
+
+        // Sequence: add 10, then multiply by 2
+        let effect = Effect::Sequence(vec![
+            Effect::ModifyGlobal {
+                property: "counter".to_string(),
+                op: ModifyOp::Add,
+                value: Expr::lit(10.0),
+            },
+            Effect::ModifyGlobal {
+                property: "counter".to_string(),
+                op: ModifyOp::Mul,
+                value: Expr::lit(2.0),
+            },
+        ]);
+
+        // Collect all writes from the sequence
+        let write_set = runtime.collect_effect(
+            &mut model,
+            &effect,
+            &EntityRef::Global,
+            &params,
+            &mut effect_result,
+        );
+
+        // Should have 2 writes
+        assert_eq!(write_set.len(), 2);
+
+        // Not mutated yet
+        assert_eq!(
+            model.get_global("counter").and_then(|v| v.as_float()),
+            Some(0.0)
+        );
+
+        // Apply: (0 + 10) * 2 = 20
+        apply(&write_set, &mut model);
+
+        assert_eq!(
+            model.get_global("counter").and_then(|v| v.as_float()),
+            Some(20.0)
+        );
+    }
+
+    /// Test that spawn entities work with collect → apply
+    #[test]
+    fn test_collect_spawn_then_apply() {
+        let mut model = Model::new();
+
+        let mut runtime = Runtime::new();
+        let mut effect_result = EffectResult::new();
+        let params = ValueMap::new();
+
+        let effect = Effect::SpawnEntity {
+            kind: DefId::new("city"),
+            properties: vec![
+                ("name".to_string(), Expr::lit("Paris")),
+                ("population".to_string(), Expr::lit(2_000_000.0)),
+            ],
+        };
+
+        // Collect
+        let write_set = runtime.collect_effect(
+            &mut model,
+            &effect,
+            &EntityRef::Global,
+            &params,
+            &mut effect_result,
+        );
+
+        // No entities yet
+        assert_eq!(model.entities.by_kind(&DefId::new("city")).count(), 0);
+
+        // Apply
+        let result = apply(&write_set, &mut model);
+
+        // Entity created
+        assert_eq!(result.spawned.len(), 1);
+        let city = model.entities.get(result.spawned[0]).unwrap();
+        assert_eq!(city.get("name").and_then(|v| v.as_str()), Some("Paris"));
+        assert_eq!(city.get_number("population"), Some(2_000_000.0));
+    }
+
+    /// Test that events are collected in EffectResult, not WriteSet
+    #[test]
+    fn test_collect_emit_event() {
+        let mut model = Model::new();
+
+        let mut runtime = Runtime::new();
+        let mut effect_result = EffectResult::new();
+        let params = ValueMap::new();
+
+        let effect = Effect::EmitEvent {
+            event: DefId::new("battle_won"),
+            target: EntityRef::Global,
+            params: vec![("damage".to_string(), Expr::lit(100.0))],
+        };
+
+        let write_set = runtime.collect_effect(
+            &mut model,
+            &effect,
+            &EntityRef::Global,
+            &params,
+            &mut effect_result,
+        );
+
+        // Events go to EffectResult, not WriteSet
+        assert!(write_set.is_empty());
+        assert_eq!(effect_result.emitted_events.len(), 1);
+        assert_eq!(effect_result.emitted_events[0].0, DefId::new("battle_won"));
+    }
+}

--- a/crates/pulsive-hub/src/lib.rs
+++ b/crates/pulsive-hub/src/lib.rs
@@ -29,6 +29,7 @@
 //! 2. **pulsive-core is standalone** - it does NOT know about pulsive-hub
 //! 3. **Core is just a wrapper** - bundles Runtime+Model, delegates all logic to pulsive-core
 
+pub mod commit;
 mod core;
 mod error;
 mod group;
@@ -36,6 +37,7 @@ mod hub;
 mod snapshot;
 mod tick_sync;
 
+pub use commit::{apply, apply_batch};
 pub use core::{Core, CoreId};
 pub use error::{Error, Result};
 pub use group::{CoreGroup, GroupId};


### PR DESCRIPTION
## Summary

Implements the foundation for deferred write semantics, establishing the infrastructure for MVCC parallel execution.

- **pulsive-core**: WriteSet/PendingWrite types + `collect_effect()` method
- **pulsive-hub**: `apply()` function for atomic write application

## Changes

### pulsive-core
- Add `WriteSet` and `PendingWrite` types for collecting writes during effect execution
- Add `WriteSetResult` for tracking spawned/destroyed entities
- Add `collect_effect()` method to `Runtime` - evaluates expressions and produces a WriteSet without mutating the Model
- Export new types from lib.rs

### pulsive-hub  
- Add `commit` module with `apply()` and `apply_batch()` functions
- `apply()` applies a WriteSet to a Model atomically
- Comprehensive integration tests demonstrating the collect → apply pattern

## Design

This establishes the core pattern for MVCC parallel execution:

```
pulsive-core                    pulsive-hub
┌─────────────┐                ┌─────────────┐
│   Runtime   │  WriteSet      │    Hub      │
│             │ ───────────────►             │
│ collect_effect()             │  apply()    │
│             │                │             │
│ (pure computation)           │ (applies writes atomically)
└─────────────┘                └─────────────┘
```

The existing `execute_effect()` remains unchanged for backward compatibility.

## Tests

- 7 WriteSet unit tests in pulsive-core
- 6 integration tests in pulsive-hub demonstrating full collect → apply pattern:
  - `test_collect_then_apply_global`
  - `test_collect_then_apply_entity`
  - `test_collect_sequence_then_apply`
  - `test_collect_spawn_then_apply`
  - `test_collect_emit_event`

## Related

- RFC #21 (MVCC Orchestrator Architecture)
- Closes #10 (Phase 1: Deferred Writes)
- Enables #23 (Snapshot & Commit API)