### PR TITLE
feat(hub): implement conflict resolution strategies

### DIFF
--- a/crates/pulsive-hub/src/conflict.rs
+++ b/crates/pulsive-hub/src/conflict.rs
@@ -29,6 +29,9 @@ use crate::CoreId;
 use pulsive_core::{DefId, EntityId, PendingWrite, WriteSet};
 use std::collections::{HashMap, HashSet};
 
+// Re-export WriteSet for convenience in resolution result
+pub use pulsive_core::WriteSet as WriteSetCore;
+
 /// The target of a write operation - used as the key for conflict detection
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub enum WriteTarget {
@@ -235,6 +238,12 @@ pub struct ConflictReport {
     pub conflicts: Vec<Conflict>,
 }
 
+impl std::fmt::Display for ConflictReport {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{} conflict(s)", self.conflicts.len())
+    }
+}
+
 impl ConflictReport {
     /// Create an empty report
     pub fn new() -> Self {
@@ -416,6 +425,410 @@ where
 /// Default filter that excludes spawn conflicts (which are usually acceptable)
 pub fn default_conflict_filter(target: &WriteTarget) -> bool {
     !matches!(target, WriteTarget::SpawnEntity { .. })
+}
+
+// ============================================================================
+// Conflict Resolution
+// ============================================================================
+
+/// A custom conflict resolver function type
+///
+/// Takes a reference to a `Conflict` and returns the winning write (if any).
+/// Return `None` to skip the conflicting write entirely.
+pub type ConflictResolver = Box<dyn Fn(&Conflict) -> Option<(CoreId, PendingWrite)> + Send + Sync>;
+
+/// Strategy for resolving write-write conflicts
+///
+/// When multiple cores write to the same target, the hub needs to decide
+/// how to handle the conflict. This enum defines the available strategies.
+///
+/// # Example
+///
+/// ```
+/// use pulsive_hub::{ResolutionStrategy, CoreId};
+///
+/// // Use first-write-wins for deterministic resolution
+/// let strategy = ResolutionStrategy::FirstWriteWins;
+///
+/// // Or use a custom resolver for complex logic
+/// let strategy = ResolutionStrategy::Custom(Box::new(|conflict| {
+///     // Always pick the write from the core with the lowest ID
+///     conflict.writes.first().cloned()
+/// }));
+/// ```
+#[derive(Default)]
+pub enum ResolutionStrategy {
+    /// Abort on any conflict - return an error
+    ///
+    /// This is the safest strategy: if any conflict is detected, the entire
+    /// merge operation fails and returns an error with the conflict report.
+    /// Use this when conflicts indicate a logic error that needs fixing.
+    #[default]
+    Abort,
+
+    /// Last write wins - take the write from the highest-CoreId core
+    ///
+    /// For deterministic resolution, "last" is defined as the core with the
+    /// highest CoreId value. This ensures consistent results across runs.
+    LastWriteWins,
+
+    /// First write wins - take the write from the lowest-CoreId core
+    ///
+    /// For deterministic resolution, "first" is defined as the core with the
+    /// lowest CoreId value. This ensures consistent results across runs.
+    FirstWriteWins,
+
+    /// Merge numeric operations when possible
+    ///
+    /// For numeric modifications (Add, Sub), this strategy combines the values.
+    /// For non-mergeable operations (Set, Mul, Div), falls back to FirstWriteWins.
+    ///
+    /// Examples:
+    /// - Core A: Add 10, Core B: Add 20 → Add 30
+    /// - Core A: Sub 5, Core B: Sub 10 → Sub 15
+    /// - Core A: Set 100, Core B: Set 200 → Set 100 (first wins)
+    Merge,
+
+    /// Custom resolution function
+    ///
+    /// Provides full control over conflict resolution. The function receives
+    /// the conflict details and returns the write to use, or None to skip.
+    Custom(ConflictResolver),
+}
+
+impl std::fmt::Debug for ResolutionStrategy {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            ResolutionStrategy::Abort => write!(f, "Abort"),
+            ResolutionStrategy::LastWriteWins => write!(f, "LastWriteWins"),
+            ResolutionStrategy::FirstWriteWins => write!(f, "FirstWriteWins"),
+            ResolutionStrategy::Merge => write!(f, "Merge"),
+            ResolutionStrategy::Custom(_) => write!(f, "Custom(<fn>)"),
+        }
+    }
+}
+
+/// Result of conflict resolution
+#[derive(Debug, Clone)]
+pub struct ResolutionResult {
+    /// The resolved WriteSet (conflicts have been resolved)
+    pub write_set: WriteSet,
+    /// Number of conflicts that were resolved
+    pub conflicts_resolved: usize,
+    /// Details of each resolution (for auditing/debugging)
+    pub resolutions: Vec<ResolvedConflict>,
+}
+
+/// Details about how a conflict was resolved
+#[derive(Debug, Clone)]
+pub struct ResolvedConflict {
+    /// The target that had a conflict
+    pub target: WriteTarget,
+    /// The cores involved in the conflict
+    pub cores: Vec<CoreId>,
+    /// The winning write (if any)
+    pub resolved_write: Option<(CoreId, PendingWrite)>,
+}
+
+impl ResolutionResult {
+    /// Create a new resolution result
+    pub fn new(write_set: WriteSet) -> Self {
+        Self {
+            write_set,
+            conflicts_resolved: 0,
+            resolutions: Vec::new(),
+        }
+    }
+
+    /// Add a resolution record
+    pub fn add_resolution(&mut self, resolution: ResolvedConflict) {
+        self.conflicts_resolved += 1;
+        self.resolutions.push(resolution);
+    }
+}
+
+/// Resolve conflicts in WriteSets using the specified strategy
+///
+/// This function detects conflicts across the provided WriteSets and resolves
+/// them according to the given strategy. If the strategy is `Abort` and
+/// conflicts are detected, returns an error.
+///
+/// # Arguments
+///
+/// * `write_sets` - WriteSets from each core with their CoreIds
+/// * `strategy` - How to resolve detected conflicts
+///
+/// # Returns
+///
+/// * `Ok(ResolutionResult)` - Successfully merged WriteSet with resolution details
+/// * `Err(Error::UnresolvedConflicts)` - If strategy is `Abort` and conflicts exist
+///
+/// # Example
+///
+/// ```
+/// use pulsive_hub::{resolve_conflicts, ResolutionStrategy, CoreId};
+/// use pulsive_core::{WriteSet, PendingWrite, Value};
+///
+/// let mut ws0 = WriteSet::new();
+/// ws0.push(PendingWrite::SetGlobal {
+///     key: "gold".to_string(),
+///     value: Value::Float(100.0),
+/// });
+///
+/// let mut ws1 = WriteSet::new();
+/// ws1.push(PendingWrite::SetGlobal {
+///     key: "gold".to_string(),
+///     value: Value::Float(200.0),
+/// });
+///
+/// let write_sets = vec![(CoreId(0), ws0), (CoreId(1), ws1)];
+///
+/// // With FirstWriteWins, Core 0's value (100) will be used
+/// let result = resolve_conflicts(&write_sets, &ResolutionStrategy::FirstWriteWins).unwrap();
+/// assert_eq!(result.conflicts_resolved, 1);
+/// ```
+pub fn resolve_conflicts(
+    write_sets: &[(CoreId, WriteSet)],
+    strategy: &ResolutionStrategy,
+) -> crate::Result<ResolutionResult> {
+    // Detect all conflicts first
+    let report = detect_conflicts(write_sets);
+
+    // If no conflicts, just merge the WriteSets
+    if !report.has_conflicts() {
+        let merged = WriteSet::merge(write_sets.iter().map(|(_, ws)| ws.clone()).collect());
+        return Ok(ResolutionResult::new(merged));
+    }
+
+    // Handle based on strategy
+    match strategy {
+        ResolutionStrategy::Abort => Err(crate::Error::UnresolvedConflicts(report)),
+
+        ResolutionStrategy::FirstWriteWins => {
+            resolve_with_strategy(write_sets, &report, |conflict| {
+                // First write = lowest CoreId
+                conflict
+                    .writes
+                    .iter()
+                    .min_by_key(|(core_id, _)| core_id.0)
+                    .cloned()
+            })
+        }
+
+        ResolutionStrategy::LastWriteWins => {
+            resolve_with_strategy(write_sets, &report, |conflict| {
+                // Last write = highest CoreId
+                conflict
+                    .writes
+                    .iter()
+                    .max_by_key(|(core_id, _)| core_id.0)
+                    .cloned()
+            })
+        }
+
+        ResolutionStrategy::Merge => resolve_with_merge(write_sets, &report),
+
+        ResolutionStrategy::Custom(resolver) => {
+            resolve_with_strategy(write_sets, &report, resolver)
+        }
+    }
+}
+
+/// Helper function to resolve conflicts using a picker function
+fn resolve_with_strategy<F>(
+    write_sets: &[(CoreId, WriteSet)],
+    report: &ConflictReport,
+    picker: F,
+) -> crate::Result<ResolutionResult>
+where
+    F: Fn(&Conflict) -> Option<(CoreId, PendingWrite)>,
+{
+    // Build a set of conflicting targets for quick lookup
+    let conflicting_targets: HashSet<WriteTarget> = report
+        .conflicts
+        .iter()
+        .map(|c| match &c.kind {
+            ConflictKind::EntityPropertyWriteWrite {
+                entity_id,
+                property,
+                ..
+            } => WriteTarget::EntityProperty {
+                entity_id: *entity_id,
+                property: property.clone(),
+            },
+            ConflictKind::EntityFlagWriteWrite {
+                entity_id, flag, ..
+            } => WriteTarget::EntityFlag {
+                entity_id: *entity_id,
+                flag: flag.clone(),
+            },
+            ConflictKind::GlobalPropertyWriteWrite { property, .. } => {
+                WriteTarget::GlobalProperty {
+                    property: property.clone(),
+                }
+            }
+            ConflictKind::SpawnEntityWriteWrite { kind, .. } => {
+                WriteTarget::SpawnEntity { kind: kind.clone() }
+            }
+            ConflictKind::DestroyEntityWriteWrite { entity_id, .. } => WriteTarget::DestroyEntity {
+                entity_id: *entity_id,
+            },
+        })
+        .collect();
+
+    let mut result = ResolutionResult::new(WriteSet::new());
+
+    // First, add all non-conflicting writes
+    for (_, ws) in write_sets {
+        for write in ws.iter() {
+            let target = WriteTarget::from_pending_write(write);
+            if !conflicting_targets.contains(&target) {
+                result.write_set.push(write.clone());
+            }
+        }
+    }
+
+    // Then, resolve each conflict
+    for conflict in &report.conflicts {
+        let target = match &conflict.kind {
+            ConflictKind::EntityPropertyWriteWrite {
+                entity_id,
+                property,
+                ..
+            } => WriteTarget::EntityProperty {
+                entity_id: *entity_id,
+                property: property.clone(),
+            },
+            ConflictKind::EntityFlagWriteWrite {
+                entity_id, flag, ..
+            } => WriteTarget::EntityFlag {
+                entity_id: *entity_id,
+                flag: flag.clone(),
+            },
+            ConflictKind::GlobalPropertyWriteWrite { property, .. } => {
+                WriteTarget::GlobalProperty {
+                    property: property.clone(),
+                }
+            }
+            ConflictKind::SpawnEntityWriteWrite { kind, .. } => {
+                WriteTarget::SpawnEntity { kind: kind.clone() }
+            }
+            ConflictKind::DestroyEntityWriteWrite { entity_id, .. } => WriteTarget::DestroyEntity {
+                entity_id: *entity_id,
+            },
+        };
+
+        let resolved_write = picker(conflict);
+
+        if let Some((_, write)) = &resolved_write {
+            result.write_set.push(write.clone());
+        }
+
+        result.add_resolution(ResolvedConflict {
+            target,
+            cores: conflict.cores.clone(),
+            resolved_write,
+        });
+    }
+
+    Ok(result)
+}
+
+/// Helper function for merge strategy - combines compatible operations
+fn resolve_with_merge(
+    write_sets: &[(CoreId, WriteSet)],
+    report: &ConflictReport,
+) -> crate::Result<ResolutionResult> {
+    use pulsive_core::ModifyOp;
+
+    resolve_with_strategy(write_sets, report, |conflict| {
+        // Check if all writes are mergeable numeric operations
+        let all_add = conflict.writes.iter().all(|(_, w)| {
+            matches!(
+                w,
+                PendingWrite::ModifyProperty {
+                    op: ModifyOp::Add,
+                    ..
+                } | PendingWrite::ModifyGlobal {
+                    op: ModifyOp::Add,
+                    ..
+                }
+            )
+        });
+
+        let all_sub = conflict.writes.iter().all(|(_, w)| {
+            matches!(
+                w,
+                PendingWrite::ModifyProperty {
+                    op: ModifyOp::Sub,
+                    ..
+                } | PendingWrite::ModifyGlobal {
+                    op: ModifyOp::Sub,
+                    ..
+                }
+            )
+        });
+
+        if all_add {
+            // Sum all Add values
+            let merged = merge_modify_writes(&conflict.writes, ModifyOp::Add);
+            merged.map(|w| (conflict.cores[0], w))
+        } else if all_sub {
+            // Sum all Sub values
+            let merged = merge_modify_writes(&conflict.writes, ModifyOp::Sub);
+            merged.map(|w| (conflict.cores[0], w))
+        } else {
+            // Fall back to first-write-wins for non-mergeable operations
+            conflict
+                .writes
+                .iter()
+                .min_by_key(|(core_id, _)| core_id.0)
+                .cloned()
+        }
+    })
+}
+
+/// Merge multiple modify operations into one
+fn merge_modify_writes(
+    writes: &[(CoreId, PendingWrite)],
+    op: pulsive_core::ModifyOp,
+) -> Option<PendingWrite> {
+    let first = writes.first()?;
+
+    match &first.1 {
+        PendingWrite::ModifyProperty { entity_id, key, .. } => {
+            let total: f64 = writes
+                .iter()
+                .filter_map(|(_, w)| match w {
+                    PendingWrite::ModifyProperty { value, .. } => Some(*value),
+                    _ => None,
+                })
+                .sum();
+
+            Some(PendingWrite::ModifyProperty {
+                entity_id: *entity_id,
+                key: key.clone(),
+                op,
+                value: total,
+            })
+        }
+        PendingWrite::ModifyGlobal { key, .. } => {
+            let total: f64 = writes
+                .iter()
+                .filter_map(|(_, w)| match w {
+                    PendingWrite::ModifyGlobal { value, .. } => Some(*value),
+                    _ => None,
+                })
+                .sum();
+
+            Some(PendingWrite::ModifyGlobal {
+                key: key.clone(),
+                op,
+                value: total,
+            })
+        }
+        _ => None,
+    }
 }
 
 #[cfg(test)]
@@ -1059,5 +1472,412 @@ mod tests {
 
         // Should have 4 total writes
         assert_eq!(report.conflicts[0].writes.len(), 4);
+    }
+
+    // ========================================================================
+    // Conflict Resolution Tests
+    // ========================================================================
+
+    #[test]
+    fn test_resolve_no_conflicts() {
+        let mut ws0 = WriteSet::new();
+        ws0.push(PendingWrite::SetGlobal {
+            key: "gold".to_string(),
+            value: Value::Float(100.0),
+        });
+
+        let mut ws1 = WriteSet::new();
+        ws1.push(PendingWrite::SetGlobal {
+            key: "silver".to_string(),
+            value: Value::Float(200.0),
+        });
+
+        let write_sets = vec![(CoreId(0), ws0), (CoreId(1), ws1)];
+
+        let result = resolve_conflicts(&write_sets, &ResolutionStrategy::Abort).unwrap();
+        assert_eq!(result.conflicts_resolved, 0);
+        assert_eq!(result.write_set.len(), 2);
+    }
+
+    #[test]
+    fn test_resolve_abort_on_conflict() {
+        let mut ws0 = WriteSet::new();
+        ws0.push(PendingWrite::SetGlobal {
+            key: "gold".to_string(),
+            value: Value::Float(100.0),
+        });
+
+        let mut ws1 = WriteSet::new();
+        ws1.push(PendingWrite::SetGlobal {
+            key: "gold".to_string(),
+            value: Value::Float(200.0),
+        });
+
+        let write_sets = vec![(CoreId(0), ws0), (CoreId(1), ws1)];
+
+        let result = resolve_conflicts(&write_sets, &ResolutionStrategy::Abort);
+        assert!(result.is_err());
+
+        match result {
+            Err(crate::Error::UnresolvedConflicts(report)) => {
+                assert_eq!(report.len(), 1);
+            }
+            _ => panic!("Expected UnresolvedConflicts error"),
+        }
+    }
+
+    #[test]
+    fn test_resolve_first_write_wins() {
+        let mut ws0 = WriteSet::new();
+        ws0.push(PendingWrite::SetGlobal {
+            key: "gold".to_string(),
+            value: Value::Float(100.0),
+        });
+
+        let mut ws1 = WriteSet::new();
+        ws1.push(PendingWrite::SetGlobal {
+            key: "gold".to_string(),
+            value: Value::Float(200.0),
+        });
+
+        let write_sets = vec![(CoreId(0), ws0), (CoreId(1), ws1)];
+
+        let result = resolve_conflicts(&write_sets, &ResolutionStrategy::FirstWriteWins).unwrap();
+        assert_eq!(result.conflicts_resolved, 1);
+        assert_eq!(result.write_set.len(), 1);
+
+        // First write wins means Core 0's value (100) should win
+        match result.write_set.iter().next() {
+            Some(PendingWrite::SetGlobal { key, value }) => {
+                assert_eq!(key, "gold");
+                assert_eq!(value.as_float(), Some(100.0));
+            }
+            _ => panic!("Expected SetGlobal write"),
+        }
+
+        // Check resolution details
+        assert_eq!(result.resolutions.len(), 1);
+        let resolution = &result.resolutions[0];
+        assert_eq!(resolution.cores, vec![CoreId(0), CoreId(1)]);
+        assert!(resolution.resolved_write.is_some());
+    }
+
+    #[test]
+    fn test_resolve_last_write_wins() {
+        let mut ws0 = WriteSet::new();
+        ws0.push(PendingWrite::SetGlobal {
+            key: "gold".to_string(),
+            value: Value::Float(100.0),
+        });
+
+        let mut ws1 = WriteSet::new();
+        ws1.push(PendingWrite::SetGlobal {
+            key: "gold".to_string(),
+            value: Value::Float(200.0),
+        });
+
+        let write_sets = vec![(CoreId(0), ws0), (CoreId(1), ws1)];
+
+        let result = resolve_conflicts(&write_sets, &ResolutionStrategy::LastWriteWins).unwrap();
+        assert_eq!(result.conflicts_resolved, 1);
+        assert_eq!(result.write_set.len(), 1);
+
+        // Last write wins means Core 1's value (200) should win
+        let writes: Vec<_> = result.write_set.iter().collect();
+        match &writes[0] {
+            PendingWrite::SetGlobal { key, value } => {
+                assert_eq!(key, "gold");
+                assert_eq!(value.as_float(), Some(200.0));
+            }
+            _ => panic!("Expected SetGlobal write"),
+        }
+    }
+
+    #[test]
+    fn test_resolve_merge_add_operations() {
+        let mut ws0 = WriteSet::new();
+        ws0.push(PendingWrite::ModifyGlobal {
+            key: "gold".to_string(),
+            op: ModifyOp::Add,
+            value: 10.0,
+        });
+
+        let mut ws1 = WriteSet::new();
+        ws1.push(PendingWrite::ModifyGlobal {
+            key: "gold".to_string(),
+            op: ModifyOp::Add,
+            value: 20.0,
+        });
+
+        let mut ws2 = WriteSet::new();
+        ws2.push(PendingWrite::ModifyGlobal {
+            key: "gold".to_string(),
+            op: ModifyOp::Add,
+            value: 30.0,
+        });
+
+        let write_sets = vec![(CoreId(0), ws0), (CoreId(1), ws1), (CoreId(2), ws2)];
+
+        let result = resolve_conflicts(&write_sets, &ResolutionStrategy::Merge).unwrap();
+        assert_eq!(result.conflicts_resolved, 1);
+        assert_eq!(result.write_set.len(), 1);
+
+        // Merge should sum all Add values: 10 + 20 + 30 = 60
+        let writes: Vec<_> = result.write_set.iter().collect();
+        match &writes[0] {
+            PendingWrite::ModifyGlobal { key, op, value } => {
+                assert_eq!(key, "gold");
+                assert!(matches!(op, ModifyOp::Add));
+                assert!((value - 60.0).abs() < f64::EPSILON);
+            }
+            _ => panic!("Expected ModifyGlobal write"),
+        }
+    }
+
+    #[test]
+    fn test_resolve_merge_sub_operations() {
+        let entity_id = EntityId::new(42);
+
+        let mut ws0 = WriteSet::new();
+        ws0.push(PendingWrite::ModifyProperty {
+            entity_id,
+            key: "health".to_string(),
+            op: ModifyOp::Sub,
+            value: 10.0,
+        });
+
+        let mut ws1 = WriteSet::new();
+        ws1.push(PendingWrite::ModifyProperty {
+            entity_id,
+            key: "health".to_string(),
+            op: ModifyOp::Sub,
+            value: 25.0,
+        });
+
+        let write_sets = vec![(CoreId(0), ws0), (CoreId(1), ws1)];
+
+        let result = resolve_conflicts(&write_sets, &ResolutionStrategy::Merge).unwrap();
+        assert_eq!(result.conflicts_resolved, 1);
+        assert_eq!(result.write_set.len(), 1);
+
+        // Merge should sum all Sub values: 10 + 25 = 35
+        let writes: Vec<_> = result.write_set.iter().collect();
+        match &writes[0] {
+            PendingWrite::ModifyProperty {
+                entity_id: eid,
+                key,
+                op,
+                value,
+            } => {
+                assert_eq!(*eid, entity_id);
+                assert_eq!(key, "health");
+                assert!(matches!(op, ModifyOp::Sub));
+                assert!((value - 35.0).abs() < f64::EPSILON);
+            }
+            _ => panic!("Expected ModifyProperty write"),
+        }
+    }
+
+    #[test]
+    fn test_resolve_merge_non_mergeable_falls_back() {
+        // Set operations cannot be merged, should fall back to first-write-wins
+        let mut ws0 = WriteSet::new();
+        ws0.push(PendingWrite::SetGlobal {
+            key: "gold".to_string(),
+            value: Value::Float(100.0),
+        });
+
+        let mut ws1 = WriteSet::new();
+        ws1.push(PendingWrite::SetGlobal {
+            key: "gold".to_string(),
+            value: Value::Float(200.0),
+        });
+
+        let write_sets = vec![(CoreId(0), ws0), (CoreId(1), ws1)];
+
+        let result = resolve_conflicts(&write_sets, &ResolutionStrategy::Merge).unwrap();
+        assert_eq!(result.conflicts_resolved, 1);
+
+        // Should fall back to first write (Core 0's value)
+        let writes: Vec<_> = result.write_set.iter().collect();
+        match &writes[0] {
+            PendingWrite::SetGlobal { key, value } => {
+                assert_eq!(key, "gold");
+                assert_eq!(value.as_float(), Some(100.0));
+            }
+            _ => panic!("Expected SetGlobal write"),
+        }
+    }
+
+    #[test]
+    fn test_resolve_custom_strategy() {
+        let mut ws0 = WriteSet::new();
+        ws0.push(PendingWrite::SetGlobal {
+            key: "gold".to_string(),
+            value: Value::Float(100.0),
+        });
+
+        let mut ws1 = WriteSet::new();
+        ws1.push(PendingWrite::SetGlobal {
+            key: "gold".to_string(),
+            value: Value::Float(200.0),
+        });
+
+        let write_sets = vec![(CoreId(0), ws0), (CoreId(1), ws1)];
+
+        // Custom strategy: always pick Core 1's value (last)
+        let strategy = ResolutionStrategy::Custom(Box::new(|conflict| {
+            conflict.writes.iter().find(|(c, _)| c.0 == 1).cloned()
+        }));
+
+        let result = resolve_conflicts(&write_sets, &strategy).unwrap();
+        assert_eq!(result.conflicts_resolved, 1);
+
+        let writes: Vec<_> = result.write_set.iter().collect();
+        match &writes[0] {
+            PendingWrite::SetGlobal { key, value } => {
+                assert_eq!(key, "gold");
+                assert_eq!(value.as_float(), Some(200.0));
+            }
+            _ => panic!("Expected SetGlobal write"),
+        }
+    }
+
+    #[test]
+    fn test_resolve_custom_strategy_skip_write() {
+        let mut ws0 = WriteSet::new();
+        ws0.push(PendingWrite::SetGlobal {
+            key: "gold".to_string(),
+            value: Value::Float(100.0),
+        });
+
+        let mut ws1 = WriteSet::new();
+        ws1.push(PendingWrite::SetGlobal {
+            key: "gold".to_string(),
+            value: Value::Float(200.0),
+        });
+
+        let write_sets = vec![(CoreId(0), ws0), (CoreId(1), ws1)];
+
+        // Custom strategy that returns None (skip the write)
+        let strategy = ResolutionStrategy::Custom(Box::new(|_| None));
+
+        let result = resolve_conflicts(&write_sets, &strategy).unwrap();
+        assert_eq!(result.conflicts_resolved, 1);
+        // No writes should be in the result (the conflicting write was skipped)
+        assert_eq!(result.write_set.len(), 0);
+
+        // Resolution should record that the write was skipped
+        assert!(result.resolutions[0].resolved_write.is_none());
+    }
+
+    #[test]
+    fn test_resolve_mixed_conflicting_and_non_conflicting() {
+        let entity_id = EntityId::new(42);
+
+        let mut ws0 = WriteSet::new();
+        // Conflicting write
+        ws0.push(PendingWrite::SetGlobal {
+            key: "gold".to_string(),
+            value: Value::Float(100.0),
+        });
+        // Non-conflicting write
+        ws0.push(PendingWrite::SetProperty {
+            entity_id,
+            key: "health".to_string(),
+            value: Value::Float(100.0),
+        });
+
+        let mut ws1 = WriteSet::new();
+        // Conflicting write
+        ws1.push(PendingWrite::SetGlobal {
+            key: "gold".to_string(),
+            value: Value::Float(200.0),
+        });
+        // Non-conflicting write (different property)
+        ws1.push(PendingWrite::SetProperty {
+            entity_id,
+            key: "mana".to_string(),
+            value: Value::Float(50.0),
+        });
+
+        let write_sets = vec![(CoreId(0), ws0), (CoreId(1), ws1)];
+
+        let result = resolve_conflicts(&write_sets, &ResolutionStrategy::FirstWriteWins).unwrap();
+        assert_eq!(result.conflicts_resolved, 1);
+        // Should have: resolved gold + health + mana = 3 writes
+        assert_eq!(result.write_set.len(), 3);
+    }
+
+    #[test]
+    fn test_resolve_multiple_conflicts() {
+        let entity_id = EntityId::new(42);
+
+        let mut ws0 = WriteSet::new();
+        ws0.push(PendingWrite::SetGlobal {
+            key: "gold".to_string(),
+            value: Value::Float(100.0),
+        });
+        ws0.push(PendingWrite::SetProperty {
+            entity_id,
+            key: "health".to_string(),
+            value: Value::Float(100.0),
+        });
+
+        let mut ws1 = WriteSet::new();
+        ws1.push(PendingWrite::SetGlobal {
+            key: "gold".to_string(),
+            value: Value::Float(200.0),
+        });
+        ws1.push(PendingWrite::SetProperty {
+            entity_id,
+            key: "health".to_string(),
+            value: Value::Float(50.0),
+        });
+
+        let write_sets = vec![(CoreId(0), ws0), (CoreId(1), ws1)];
+
+        let result = resolve_conflicts(&write_sets, &ResolutionStrategy::LastWriteWins).unwrap();
+        assert_eq!(result.conflicts_resolved, 2);
+        assert_eq!(result.write_set.len(), 2);
+
+        // Both should be Core 1's values (last write wins)
+        for write in result.write_set.iter() {
+            match write {
+                PendingWrite::SetGlobal { key, value } => {
+                    assert_eq!(key, "gold");
+                    assert_eq!(value.as_float(), Some(200.0));
+                }
+                PendingWrite::SetProperty { key, value, .. } => {
+                    assert_eq!(key, "health");
+                    assert_eq!(value.as_float(), Some(50.0));
+                }
+                _ => panic!("Unexpected write type"),
+            }
+        }
+    }
+
+    #[test]
+    fn test_resolution_strategy_debug() {
+        assert_eq!(format!("{:?}", ResolutionStrategy::Abort), "Abort");
+        assert_eq!(
+            format!("{:?}", ResolutionStrategy::FirstWriteWins),
+            "FirstWriteWins"
+        );
+        assert_eq!(
+            format!("{:?}", ResolutionStrategy::LastWriteWins),
+            "LastWriteWins"
+        );
+        assert_eq!(format!("{:?}", ResolutionStrategy::Merge), "Merge");
+        assert_eq!(
+            format!("{:?}", ResolutionStrategy::Custom(Box::new(|_| None))),
+            "Custom(<fn>)"
+        );
+    }
+
+    #[test]
+    fn test_resolution_strategy_default() {
+        let strategy = ResolutionStrategy::default();
+        assert!(matches!(strategy, ResolutionStrategy::Abort));
     }
 }

--- a/crates/pulsive-hub/src/error.rs
+++ b/crates/pulsive-hub/src/error.rs
@@ -1,4 +1,9 @@
 //! Error types for pulsive-hub
+//!
+//! Note: This module imports `ConflictReport` from `conflict.rs`, while `conflict.rs`
+//! uses `crate::Error` and `crate::Result`. This is not a problematic circular dependency
+//! in Rust because both modules are in the same crate and the types are only used in
+//! function signatures, not in mutually-dependent struct definitions.
 
 use crate::conflict::ConflictReport;
 use thiserror::Error;
@@ -21,10 +26,44 @@ pub enum Error {
     ///
     /// This error is returned when conflicts are detected and the resolution
     /// strategy is `Abort`, or when conflicts cannot be automatically resolved.
-    #[error("unresolved conflicts: {0} conflict(s) detected")]
-    UnresolvedConflicts(ConflictReport),
+    ///
+    /// The `report` field contains the full conflict details (boxed to avoid
+    /// large error sizes during propagation). Use [`Error::conflict_report()`]
+    /// for convenient access.
+    #[error("unresolved conflicts: {count} conflict(s) detected")]
+    UnresolvedConflicts {
+        /// Number of conflicts detected
+        count: usize,
+        /// Full conflict report with details (boxed to reduce error size)
+        report: Box<ConflictReport>,
+    },
 
     /// Core error
     #[error("core error: {0}")]
     Core(#[from] pulsive_core::Error),
+}
+
+impl Error {
+    /// Create an UnresolvedConflicts error from a ConflictReport
+    pub fn unresolved_conflicts(report: ConflictReport) -> Self {
+        Error::UnresolvedConflicts {
+            count: report.len(),
+            report: Box::new(report),
+        }
+    }
+
+    /// Get the conflict report if this is an UnresolvedConflicts error
+    pub fn conflict_report(&self) -> Option<&ConflictReport> {
+        match self {
+            Error::UnresolvedConflicts { report, .. } => Some(report),
+            _ => None,
+        }
+    }
+}
+
+// Compile-time check that Error is Send + Sync for thread-safe error propagation.
+// This function is never called but will fail to compile if the bound is not satisfied.
+fn _assert_error_send_sync<T: Send + Sync>() {}
+fn _error_is_send_sync() {
+    _assert_error_send_sync::<Error>();
 }

--- a/crates/pulsive-hub/src/error.rs
+++ b/crates/pulsive-hub/src/error.rs
@@ -30,7 +30,7 @@ pub enum Error {
     /// The `report` field contains the full conflict details (boxed to avoid
     /// large error sizes during propagation). Use [`Error::conflict_report()`]
     /// for convenient access.
-    #[error("unresolved conflicts: {count} conflict(s) detected")]
+    #[error("unresolved conflicts: {}", Self::format_conflict_count(*.count))]
     UnresolvedConflicts {
         /// Number of conflicts detected
         count: usize,
@@ -57,6 +57,15 @@ impl Error {
         match self {
             Error::UnresolvedConflicts { report, .. } => Some(report),
             _ => None,
+        }
+    }
+
+    /// Format conflict count with proper pluralization
+    fn format_conflict_count(count: usize) -> String {
+        if count == 1 {
+            "1 conflict detected".to_string()
+        } else {
+            format!("{} conflicts detected", count)
         }
     }
 }

--- a/crates/pulsive-hub/src/error.rs
+++ b/crates/pulsive-hub/src/error.rs
@@ -1,5 +1,6 @@
 //! Error types for pulsive-hub
 
+use crate::conflict::ConflictReport;
 use thiserror::Error;
 
 /// Result type for pulsive-hub operations
@@ -15,6 +16,13 @@ pub enum Error {
     /// Group not found
     #[error("group {0:?} not found")]
     GroupNotFound(crate::GroupId),
+
+    /// Unresolved conflicts during WriteSets merge
+    ///
+    /// This error is returned when conflicts are detected and the resolution
+    /// strategy is `Abort`, or when conflicts cannot be automatically resolved.
+    #[error("unresolved conflicts: {0} conflict(s) detected")]
+    UnresolvedConflicts(ConflictReport),
 
     /// Core error
     #[error("core error: {0}")]

--- a/crates/pulsive-hub/src/lib.rs
+++ b/crates/pulsive-hub/src/lib.rs
@@ -40,8 +40,9 @@ mod tick_sync;
 
 pub use commit::{apply, apply_batch};
 pub use conflict::{
-    default_conflict_filter, detect_conflicts, detect_conflicts_filtered, Conflict, ConflictKind,
-    ConflictReport, WriteTarget,
+    default_conflict_filter, detect_conflicts, detect_conflicts_filtered, resolve_conflicts,
+    Conflict, ConflictKind, ConflictReport, ConflictResolver, ResolutionResult, ResolutionStrategy,
+    ResolvedConflict, WriteTarget,
 };
 pub use core::{Core, CoreId};
 pub use error::{Error, Result};


### PR DESCRIPTION
## Summary
Implements Issue #25: pulsive-hub Conflict Resolution Strategies.

## Changes
- Add `ResolutionStrategy` enum with 5 resolution modes:
  - **Abort**: Error on any conflict (default, safest)
  - **FirstWriteWins**: Pick lowest CoreId write deterministically
  - **LastWriteWins**: Pick highest CoreId write deterministically
  - **Merge**: Combine compatible numeric operations (Add/Sub)
  - **Custom**: User-defined resolution function via `ConflictResolver` type
  
- Add `resolve_conflicts()` function that detects and resolves conflicts
- Add `ConflictResolver` type alias for custom resolver functions
- Add `ResolutionResult` with resolved WriteSet and audit trail
- Add `UnresolvedConflicts` error variant
- Add `Display
