### PR TITLE
feat(hub): implement Snapshot & Commit API

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ fn main() {
     let mut runtime = Runtime::new();
     
     // Create an entity
-    let entity = model.entities.create("sensor");
+    let entity = model.entities_mut().create("sensor");
     entity.set("temperature", 22.5);
     entity.set("location", "room_1");
     

--- a/crates/pulsive-core/src/lib.rs
+++ b/crates/pulsive-core/src/lib.rs
@@ -58,5 +58,8 @@ pub use time::{Clock, Speed, Tick, Timestamp};
 pub use value::{Value, ValueMap};
 pub use write_set::{PendingWrite, WriteSet, WriteSetResult};
 
+// Re-export indexmap for consumers that need it with actor maps
+pub use indexmap::IndexMap;
+
 #[cfg(feature = "journal")]
 pub use journal::{Journal, JournalConfig, JournalEntry, JournalStats, Snapshot, SnapshotId};

--- a/crates/pulsive-core/src/model.rs
+++ b/crates/pulsive-core/src/model.rs
@@ -1,16 +1,27 @@
 //! System model (state)
+//!
+//! The Model uses `Arc` for structural sharing, enabling O(1) snapshot creation.
+//! Mutations use copy-on-write semantics via `Arc::make_mut()`.
 
-use crate::{ActorId, Clock, Context, EntityStore, Rng, ValueMap};
+use crate::{ActorId, Clock, Context, EntityStore, Rng, Value, ValueMap};
 use indexmap::IndexMap;
 use serde::{Deserialize, Serialize};
+use std::sync::Arc;
 
 /// The complete system state
+///
+/// Uses `Arc` for entities and globals to enable efficient snapshotting:
+/// - Snapshot creation is O(1) (just Arc clone)
+/// - Mutations use copy-on-write (only clones if shared)
+/// - Multiple snapshots can share underlying data
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Model {
-    /// All entities in the system
-    pub entities: EntityStore,
-    /// Global properties
-    pub globals: ValueMap,
+    /// All entities in the system (Arc for structural sharing)
+    #[serde(with = "arc_entity_store")]
+    entities: Arc<EntityStore>,
+    /// Global properties (Arc for structural sharing)
+    #[serde(with = "arc_value_map")]
+    globals: Arc<ValueMap>,
     /// System clock
     pub time: Clock,
     /// Deterministic RNG
@@ -19,12 +30,52 @@ pub struct Model {
     pub actors: IndexMap<ActorId, Context>,
 }
 
+// Custom serde for Arc<EntityStore>
+mod arc_entity_store {
+    use super::*;
+    use serde::{Deserializer, Serializer};
+
+    pub fn serialize<S>(data: &Arc<EntityStore>, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        data.as_ref().serialize(serializer)
+    }
+
+    pub fn deserialize<'de, D>(deserializer: D) -> Result<Arc<EntityStore>, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        EntityStore::deserialize(deserializer).map(Arc::new)
+    }
+}
+
+// Custom serde for Arc<ValueMap>
+mod arc_value_map {
+    use super::*;
+    use serde::{Deserializer, Serializer};
+
+    pub fn serialize<S>(data: &Arc<ValueMap>, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        data.as_ref().serialize(serializer)
+    }
+
+    pub fn deserialize<'de, D>(deserializer: D) -> Result<Arc<ValueMap>, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        ValueMap::deserialize(deserializer).map(Arc::new)
+    }
+}
+
 impl Model {
     /// Create a new empty model
     pub fn new() -> Self {
         Self {
-            entities: EntityStore::new(),
-            globals: ValueMap::new(),
+            entities: Arc::new(EntityStore::new()),
+            globals: Arc::new(ValueMap::new()),
             time: Clock::new(),
             rng: Rng::new(12345),
             actors: IndexMap::new(),
@@ -34,23 +85,89 @@ impl Model {
     /// Create with a specific RNG seed
     pub fn with_seed(seed: u64) -> Self {
         Self {
-            entities: EntityStore::new(),
-            globals: ValueMap::new(),
+            entities: Arc::new(EntityStore::new()),
+            globals: Arc::new(ValueMap::new()),
             time: Clock::new(),
             rng: Rng::new(seed),
             actors: IndexMap::new(),
         }
     }
 
+    /// Create a Model from snapshot data
+    ///
+    /// Used when reconstructing a Model from a snapshot. All fields are
+    /// restored to match the original model state.
+    pub fn from_snapshot_data(
+        entities: EntityStore,
+        globals: ValueMap,
+        time: Clock,
+        rng: Rng,
+        actors: IndexMap<ActorId, Context>,
+    ) -> Self {
+        Self {
+            entities: Arc::new(entities),
+            globals: Arc::new(globals),
+            time,
+            rng,
+            actors,
+        }
+    }
+
+    // ========================================================================
+    // Entity Access
+    // ========================================================================
+
+    /// Get a reference to the entity store (for reading)
+    pub fn entities(&self) -> &EntityStore {
+        &self.entities
+    }
+
+    /// Get a mutable reference to the entity store (copy-on-write)
+    ///
+    /// Uses `Arc::make_mut()` for copy-on-write semantics:
+    /// - If this is the only reference, mutates in place
+    /// - If shared with snapshots, clones before mutating
+    pub fn entities_mut(&mut self) -> &mut EntityStore {
+        Arc::make_mut(&mut self.entities)
+    }
+
+    /// Get the Arc-wrapped entity store (for O(1) snapshot creation)
+    pub fn entities_arc(&self) -> Arc<EntityStore> {
+        Arc::clone(&self.entities)
+    }
+
+    // ========================================================================
+    // Global Property Access
+    // ========================================================================
+
+    /// Get a reference to the globals map (for reading)
+    pub fn globals(&self) -> &ValueMap {
+        &self.globals
+    }
+
+    /// Get a mutable reference to the globals map (copy-on-write)
+    pub fn globals_mut(&mut self) -> &mut ValueMap {
+        Arc::make_mut(&mut self.globals)
+    }
+
+    /// Get the Arc-wrapped globals map (for O(1) snapshot creation)
+    pub fn globals_arc(&self) -> Arc<ValueMap> {
+        Arc::clone(&self.globals)
+    }
+
     /// Get a global property
-    pub fn get_global(&self, key: &str) -> Option<&crate::Value> {
+    pub fn get_global(&self, key: &str) -> Option<&Value> {
         self.globals.get(key)
     }
 
-    /// Set a global property
-    pub fn set_global(&mut self, key: impl Into<String>, value: impl Into<crate::Value>) {
-        self.globals.insert(key.into(), value.into());
+    /// Set a global property (triggers copy-on-write if shared)
+    pub fn set_global(&mut self, key: impl Into<String>, value: impl Into<Value>) {
+        Arc::make_mut(&mut self.globals).insert(key.into(), value.into());
     }
+
+    // ========================================================================
+    // Actor Management
+    // ========================================================================
 
     /// Add an actor
     pub fn add_actor(&mut self, actor: Context) {
@@ -67,6 +184,20 @@ impl Model {
         self.actors.get_mut(&id)
     }
 
+    /// Get all actors
+    pub fn actors(&self) -> &IndexMap<ActorId, Context> {
+        &self.actors
+    }
+
+    // ========================================================================
+    // Time Management
+    // ========================================================================
+
+    /// Get the clock
+    pub fn clock(&self) -> &Clock {
+        &self.time
+    }
+
     /// Advance the clock by one tick
     pub fn advance_tick(&mut self) {
         self.time.advance();
@@ -75,6 +206,32 @@ impl Model {
     /// Get the current tick
     pub fn current_tick(&self) -> u64 {
         self.time.tick
+    }
+
+    // ========================================================================
+    // RNG Access
+    // ========================================================================
+
+    /// Get the RNG state (for snapshotting)
+    pub fn rng(&self) -> &Rng {
+        &self.rng
+    }
+
+    // ========================================================================
+    // Evaluation Context Support
+    // ========================================================================
+
+    /// Get entities, globals, and rng references for creating an EvalContext
+    ///
+    /// This method allows simultaneous borrowing of entities/globals (immutable)
+    /// and rng (mutable) which is needed for expression evaluation.
+    ///
+    /// # Returns
+    ///
+    /// A tuple of `(&EntityStore, &ValueMap, &mut Rng)` that can be passed
+    /// to `EvalContext::new()`.
+    pub fn eval_refs(&mut self) -> (&EntityStore, &ValueMap, &mut Rng) {
+        (&self.entities, &self.globals, &mut self.rng)
     }
 }
 
@@ -87,7 +244,6 @@ impl Default for Model {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::Value;
 
     #[test]
     fn test_model_globals() {
@@ -105,5 +261,66 @@ mod tests {
 
         assert!(model.get_actor(ActorId::new(1)).is_some());
         assert!(model.get_actor(ActorId::new(2)).is_none());
+    }
+
+    #[test]
+    fn test_model_arc_sharing() {
+        let mut model = Model::new();
+        model.set_global("gold", 100.0f64);
+
+        // Get Arc references before mutation
+        let entities_arc = model.entities_arc();
+        let globals_arc = model.globals_arc();
+
+        // Clone model (simulates snapshot creation)
+        let snapshot = model.clone();
+
+        // Arcs should be shared (same pointer)
+        assert!(Arc::ptr_eq(&entities_arc, &snapshot.entities_arc()));
+        assert!(Arc::ptr_eq(&globals_arc, &snapshot.globals_arc()));
+
+        // Mutate original - should trigger copy-on-write
+        model.set_global("gold", 200.0f64);
+
+        // Now they should be different
+        assert!(!Arc::ptr_eq(&model.globals_arc(), &snapshot.globals_arc()));
+
+        // But entities should still be shared (no entity mutation)
+        assert!(Arc::ptr_eq(&model.entities_arc(), &snapshot.entities_arc()));
+
+        // Values should be independent
+        assert_eq!(
+            model.get_global("gold").and_then(|v| v.as_float()),
+            Some(200.0)
+        );
+        assert_eq!(
+            snapshot.get_global("gold").and_then(|v| v.as_float()),
+            Some(100.0)
+        );
+    }
+
+    #[test]
+    fn test_model_entity_cow() {
+        let mut model = Model::new();
+        model.entities_mut().create("nation").set("name", "France");
+
+        // Clone model
+        let snapshot = model.clone();
+
+        // Arcs should be shared
+        assert!(Arc::ptr_eq(&model.entities_arc(), &snapshot.entities_arc()));
+
+        // Mutate original entity store
+        model.entities_mut().create("nation").set("name", "England");
+
+        // Now they should be different (copy-on-write triggered)
+        assert!(!Arc::ptr_eq(
+            &model.entities_arc(),
+            &snapshot.entities_arc()
+        ));
+
+        // Original has 2 nations, snapshot has 1
+        assert_eq!(model.entities().len(), 2);
+        assert_eq!(snapshot.entities().len(), 1);
     }
 }

--- a/crates/pulsive-db/src/store.rs
+++ b/crates/pulsive-db/src/store.rs
@@ -133,13 +133,13 @@ impl Store {
         let rw = self.db.rw_transaction()?;
 
         // Save all entities
-        for entity in model.entities.iter() {
+        for entity in model.entities().iter() {
             let stored = StoredEntity::from_entity(entity);
             rw.upsert(stored)?;
         }
 
         // Save globals
-        let globals = StoredGlobals::from_globals(&model.globals);
+        let globals = StoredGlobals::from_globals(model.globals());
         rw.upsert(globals)?;
 
         // Save time
@@ -162,13 +162,14 @@ impl Store {
         for entity in self.load_all_entities()? {
             // Insert entity into the store
             let kind = entity.kind.clone();
-            let new_entity = model.entities.create(kind);
+            let new_entity = model.entities_mut().create(kind);
             new_entity.properties = entity.properties;
             new_entity.flags = entity.flags;
         }
 
         // Load globals
-        model.globals = self.load_globals()?;
+        let loaded_globals = self.load_globals()?;
+        *model.globals_mut() = loaded_globals;
 
         // Load time
         if let Some(time) = self.load_clock()? {

--- a/crates/pulsive-godot/src/engine.rs
+++ b/crates/pulsive-godot/src/engine.rs
@@ -125,7 +125,7 @@ impl PulsiveEngine {
     /// Create a new entity of the given type
     #[func]
     fn create_entity(&mut self, kind: GString) -> i64 {
-        let entity = self.model.entities.create(kind.to_string());
+        let entity = self.model.entities_mut().create(kind.to_string());
         entity.id.raw() as i64
     }
 
@@ -133,7 +133,7 @@ impl PulsiveEngine {
     #[func]
     fn get_property(&self, entity_id: i64, property: GString) -> Variant {
         let id = pulsive_core::EntityId::new(entity_id as u64);
-        if let Some(entity) = self.model.entities.get(id) {
+        if let Some(entity) = self.model.entities().get(id) {
             if let Some(value) = entity.get(&property.to_string()) {
                 return value_to_variant(value);
             }
@@ -145,7 +145,7 @@ impl PulsiveEngine {
     #[func]
     fn set_property(&mut self, entity_id: i64, property: GString, value: Variant) {
         let id = pulsive_core::EntityId::new(entity_id as u64);
-        if let Some(entity) = self.model.entities.get_mut(id) {
+        if let Some(entity) = self.model.entities_mut().get_mut(id) {
             entity.set(property.to_string(), variant_to_value(&value));
         }
     }
@@ -154,7 +154,7 @@ impl PulsiveEngine {
     #[func]
     fn get_entity(&self, entity_id: i64) -> VarDictionary {
         let id = pulsive_core::EntityId::new(entity_id as u64);
-        if let Some(entity) = self.model.entities.get(id) {
+        if let Some(entity) = self.model.entities().get(id) {
             return value_map_to_dict(&entity.properties);
         }
         VarDictionary::new()
@@ -164,7 +164,7 @@ impl PulsiveEngine {
     #[func]
     fn delete_entity(&mut self, entity_id: i64) -> bool {
         let id = pulsive_core::EntityId::new(entity_id as u64);
-        self.model.entities.remove(id).is_some()
+        self.model.entities_mut().remove(id).is_some()
     }
 
     /// Get all entity IDs of a given type
@@ -173,7 +173,7 @@ impl PulsiveEngine {
         let def_id = DefId::new(kind.to_string());
         let ids: Vec<i64> = self
             .model
-            .entities
+            .entities()
             .by_kind(&def_id)
             .map(|e| e.id.raw() as i64)
             .collect();

--- a/crates/pulsive-hub/src/lib.rs
+++ b/crates/pulsive-hub/src/lib.rs
@@ -38,7 +38,7 @@ mod hub;
 mod snapshot;
 mod tick_sync;
 
-pub use commit::{apply, apply_batch};
+pub use commit::{apply, apply_batch, commit, commit_batch, has_conflicts, CommitResult};
 pub use conflict::{
     default_conflict_filter, detect_conflicts, detect_conflicts_filtered, resolve_conflicts,
     Conflict, ConflictReport, ConflictResolver, ConflictTarget, ConflictType, ResolutionResult,

--- a/crates/pulsive-hub/src/snapshot.rs
+++ b/crates/pulsive-hub/src/snapshot.rs
@@ -1,40 +1,141 @@
 //! ModelSnapshot - Immutable view of the model for parallel reads
 //!
-//! Currently a simple wrapper around Model::clone().
-//! Future optimizations could use:
-//! - Arc sharing for unchanged data
-//! - Copy-on-write for entities
-//! - Structural sharing
+//! Provides thread-safe, immutable snapshots of the model state that can be
+//! shared across multiple cores for parallel execution.
+//!
+//! # Design
+//!
+//! Snapshots use `Arc` for efficient structural sharing:
+//! - **Creating a snapshot is O(1)**: Just clones Arc references from Model
+//! - **Cloning a snapshot is O(1)**: Increments Arc reference counts
+//! - **Multiple snapshots share data**: Until Model is mutated (copy-on-write)
+//!
+//! Model stores its entities and globals in `Arc`, so snapshot creation is just
+//! cloning the Arc references - no data copying occurs.
+//!
+//! # Example
+//!
+//! ```rust,ignore
+//! use pulsive_hub::{Hub, ModelSnapshot};
+//!
+//! let hub = Hub::new();
+//! let snapshot = hub.snapshot();
+//!
+//! // Read entities
+//! if let Some(entity) = snapshot.get_entity(entity_id) {
+//!     println!("Entity gold: {:?}", entity.get_number("gold"));
+//! }
+//!
+//! // Read globals
+//! if let Some(value) = snapshot.get_global("game_speed") {
+//!     println!("Game speed: {:?}", value);
+//! }
+//! ```
 
-use pulsive_core::Model;
+use pulsive_core::{
+    ActorId, Clock, Context, DefId, Entity, EntityId, EntityStore, IndexMap, Model, Rng, Value,
+    ValueMap,
+};
+use std::sync::Arc;
 
 /// An immutable snapshot of the model at a point in time
 ///
 /// Used to provide consistent read access to cores during parallel execution.
 /// Each core receives a snapshot and can read from it without synchronization.
+///
+/// # Full State Preservation
+///
+/// The snapshot preserves *all* model state for deterministic replay:
+/// - Entities and globals (Arc-wrapped for O(1) cloning)
+/// - Clock state (tick, speed, start date)
+/// - RNG state (for deterministic random number generation)
+/// - Actor contexts
+///
+/// # Performance
+///
+/// - **Creation**: O(1) for entities/globals (Arc clone), O(n) for actors
+/// - **Clone**: O(1) for entities/globals, O(n) for actors
+/// - **Read**: O(1) - direct access to underlying data
+///
+/// # Thread Safety
+///
+/// `ModelSnapshot` is `Send + Sync` (auto-derived via Arc), allowing safe
+/// sharing across threads for parallel reads.
 #[derive(Debug, Clone)]
 pub struct ModelSnapshot {
-    /// The model state at snapshot time
-    model: Model,
-    /// The tick when this snapshot was taken
-    tick: u64,
+    /// Shared entity storage
+    entities: Arc<EntityStore>,
+    /// Shared global properties
+    globals: Arc<ValueMap>,
+    /// Clock state (for full time restoration)
+    time: Clock,
+    /// RNG state (for deterministic replay)
+    rng: Rng,
+    /// Actor contexts
+    actors: IndexMap<ActorId, Context>,
     /// Version number (for MVCC)
     version: u64,
 }
 
 impl ModelSnapshot {
     /// Create a new snapshot from a model
+    ///
+    /// Captures the full model state for deterministic replay:
+    /// - Entities and globals: O(1) Arc clone
+    /// - Clock, RNG, actors: O(n) clone
     pub fn new(model: &Model, version: u64) -> Self {
         Self {
-            tick: model.current_tick(),
-            model: model.clone(),
+            // O(1) - just clone Arc references
+            entities: model.entities_arc(),
+            globals: model.globals_arc(),
+            // Full state for deterministic replay
+            time: model.clock().clone(),
+            rng: model.rng().clone(),
+            actors: model.actors().clone(),
+            version,
+        }
+    }
+
+    /// Create a snapshot with pre-wrapped Arc data
+    ///
+    /// Used internally when the caller already has Arc-wrapped data.
+    #[allow(dead_code)] // Will be used in future optimizations
+    pub(crate) fn from_arcs(
+        entities: Arc<EntityStore>,
+        globals: Arc<ValueMap>,
+        time: Clock,
+        rng: Rng,
+        actors: IndexMap<ActorId, Context>,
+        version: u64,
+    ) -> Self {
+        Self {
+            entities,
+            globals,
+            time,
+            rng,
+            actors,
             version,
         }
     }
 
     /// Get the tick this snapshot was taken at
     pub fn tick(&self) -> u64 {
-        self.tick
+        self.time.tick
+    }
+
+    /// Get the clock state
+    pub fn clock(&self) -> &Clock {
+        &self.time
+    }
+
+    /// Get the RNG state
+    pub fn rng(&self) -> &Rng {
+        &self.rng
+    }
+
+    /// Get the actor contexts
+    pub fn actors(&self) -> &IndexMap<ActorId, Context> {
+        &self.actors
     }
 
     /// Get the version number
@@ -42,15 +143,300 @@ impl ModelSnapshot {
         self.version
     }
 
+    // ========================================================================
+    // Entity Read Methods
+    // ========================================================================
+
+    /// Get an entity by ID
+    ///
+    /// Returns an immutable reference to the entity if it exists.
+    pub fn get_entity(&self, id: EntityId) -> Option<&Entity> {
+        self.entities.get(id)
+    }
+
+    /// Iterate over all entities of a given kind
+    ///
+    /// # Example
+    ///
+    /// ```rust,ignore
+    /// for entity in snapshot.entities_by_kind(&DefId::new("nation")) {
+    ///     println!("{}: gold = {:?}", entity.id, entity.get_number("gold"));
+    /// }
+    /// ```
+    pub fn entities_by_kind(&self, kind: &DefId) -> impl Iterator<Item = &Entity> {
+        self.entities.by_kind(kind)
+    }
+
+    /// Iterate over all entities
+    pub fn entities(&self) -> impl Iterator<Item = &Entity> {
+        self.entities.iter()
+    }
+
+    /// Get the number of entities
+    pub fn entity_count(&self) -> usize {
+        self.entities.len()
+    }
+
+    /// Check if an entity exists
+    pub fn has_entity(&self, id: EntityId) -> bool {
+        self.entities.get(id).is_some()
+    }
+
+    // ========================================================================
+    // Global Read Methods
+    // ========================================================================
+
+    /// Get a global property value
+    ///
+    /// Returns an immutable reference to the value if it exists.
+    pub fn get_global(&self, key: &str) -> Option<&Value> {
+        self.globals.get(key)
+    }
+
+    /// Get a global property as a float
+    pub fn get_global_number(&self, key: &str) -> Option<f64> {
+        self.globals.get(key).and_then(|v| v.as_float())
+    }
+
+    /// Get a global property as a string
+    pub fn get_global_str(&self, key: &str) -> Option<&str> {
+        self.globals.get(key).and_then(|v| v.as_str())
+    }
+
+    /// Check if a global property exists
+    pub fn has_global(&self, key: &str) -> bool {
+        self.globals.contains_key(key)
+    }
+
+    /// Iterate over all global properties
+    pub fn globals_iter(&self) -> impl Iterator<Item = (&String, &Value)> {
+        self.globals.iter()
+    }
+
+    // ========================================================================
+    // Conversion Methods
+    // ========================================================================
+
     /// Convert to an owned Model for a core to use
     ///
     /// Each core gets its own mutable copy to work with.
+    /// This clones all state including entities, globals, RNG, and actors
+    /// for deterministic replay/parallel execution.
     pub fn to_model(&self) -> Model {
-        self.model.clone()
+        Model::from_snapshot_data(
+            (*self.entities).clone(),
+            (*self.globals).clone(),
+            self.time.clone(),
+            self.rng.clone(),
+            self.actors.clone(),
+        )
     }
 
-    /// Get a reference to the underlying model (for reading)
-    pub fn model(&self) -> &Model {
-        &self.model
+    /// Get a reference to the underlying entity store
+    ///
+    /// Useful when you need direct access to EntityStore methods.
+    pub fn entity_store(&self) -> &EntityStore {
+        &self.entities
+    }
+
+    /// Get a reference to the underlying globals map
+    pub fn globals_map(&self) -> &ValueMap {
+        &self.globals
+    }
+
+    /// Get the Arc-wrapped entity store (for efficient sharing)
+    pub fn entities_arc(&self) -> Arc<EntityStore> {
+        Arc::clone(&self.entities)
+    }
+
+    /// Get the Arc-wrapped globals map (for efficient sharing)
+    pub fn globals_arc(&self) -> Arc<ValueMap> {
+        Arc::clone(&self.globals)
+    }
+}
+
+// ModelSnapshot is automatically Send + Sync because:
+// - Arc<T> is Send + Sync when T: Send + Sync
+// - EntityStore and ValueMap are both Send + Sync
+// No unsafe impl needed - compiler derives these automatically.
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_snapshot_creation() {
+        let mut model = Model::new();
+        model.set_global("gold", 100.0f64);
+        model.advance_tick();
+        model.advance_tick();
+
+        let snapshot = ModelSnapshot::new(&model, 1);
+
+        assert_eq!(snapshot.tick(), 2);
+        assert_eq!(snapshot.version(), 1);
+    }
+
+    #[test]
+    fn test_snapshot_read_global() {
+        let mut model = Model::new();
+        model.set_global("gold", 100.0f64);
+        model.set_global("name", "TestGame");
+
+        let snapshot = ModelSnapshot::new(&model, 1);
+
+        assert_eq!(snapshot.get_global_number("gold"), Some(100.0));
+        assert_eq!(snapshot.get_global_str("name"), Some("TestGame"));
+        assert!(snapshot.has_global("gold"));
+        assert!(!snapshot.has_global("silver"));
+    }
+
+    #[test]
+    fn test_snapshot_read_entity() {
+        let mut model = Model::new();
+        let entity = model.entities_mut().create("nation");
+        entity.set("name", "France");
+        entity.set("gold", 500.0f64);
+        let entity_id = entity.id;
+
+        let snapshot = ModelSnapshot::new(&model, 1);
+
+        let entity = snapshot.get_entity(entity_id).unwrap();
+        assert_eq!(entity.get("name").and_then(|v| v.as_str()), Some("France"));
+        assert_eq!(entity.get_number("gold"), Some(500.0));
+        assert!(snapshot.has_entity(entity_id));
+    }
+
+    #[test]
+    fn test_snapshot_entities_by_kind() {
+        let mut model = Model::new();
+        model.entities_mut().create("nation").set("name", "France");
+        model.entities_mut().create("nation").set("name", "England");
+        model.entities_mut().create("province").set("name", "Paris");
+
+        let snapshot = ModelSnapshot::new(&model, 1);
+
+        assert_eq!(snapshot.entities_by_kind(&DefId::new("nation")).count(), 2);
+        assert_eq!(
+            snapshot.entities_by_kind(&DefId::new("province")).count(),
+            1
+        );
+        assert_eq!(snapshot.entity_count(), 3);
+    }
+
+    #[test]
+    fn test_snapshot_immutability() {
+        let mut model = Model::new();
+        model.set_global("gold", 100.0f64);
+
+        let snapshot = ModelSnapshot::new(&model, 1);
+
+        // Modify the original model
+        model.set_global("gold", 200.0f64);
+
+        // Snapshot should still have original value
+        assert_eq!(snapshot.get_global_number("gold"), Some(100.0));
+    }
+
+    #[test]
+    fn test_snapshot_to_model() {
+        let mut model = Model::new();
+        model.set_global("gold", 100.0f64);
+        model.entities_mut().create("nation").set("name", "France");
+        model.advance_tick();
+        model.advance_tick();
+        model.advance_tick();
+
+        let snapshot = ModelSnapshot::new(&model, 1);
+        let restored = snapshot.to_model();
+
+        assert_eq!(restored.current_tick(), 3);
+        assert_eq!(
+            restored.get_global("gold").and_then(|v| v.as_float()),
+            Some(100.0)
+        );
+        assert_eq!(restored.entities().len(), 1);
+    }
+
+    #[test]
+    fn test_snapshot_arc_sharing() {
+        let mut model = Model::new();
+        model.set_global("gold", 100.0f64);
+
+        let snapshot1 = ModelSnapshot::new(&model, 1);
+        let snapshot2 = snapshot1.clone();
+
+        // Both snapshots share the same underlying data
+        assert!(Arc::ptr_eq(&snapshot1.entities, &snapshot2.entities));
+        assert!(Arc::ptr_eq(&snapshot1.globals, &snapshot2.globals));
+    }
+
+    #[test]
+    fn test_snapshot_o1_creation() {
+        // Verify that snapshot creation is O(1) by checking Arc sharing with Model
+        let mut model = Model::new();
+        model.set_global("gold", 100.0f64);
+        model.entities_mut().create("nation").set("name", "France");
+
+        // Get Arc references from model before creating snapshot
+        let model_entities_arc = model.entities_arc();
+        let model_globals_arc = model.globals_arc();
+
+        // Create snapshot - should share the same Arcs (O(1), no data copy)
+        let snapshot = ModelSnapshot::new(&model, 1);
+
+        // Snapshot Arcs should point to same data as Model Arcs
+        assert!(Arc::ptr_eq(&model_entities_arc, &snapshot.entities_arc()));
+        assert!(Arc::ptr_eq(&model_globals_arc, &snapshot.globals_arc()));
+
+        // Multiple snapshots also share the same data
+        let snapshot2 = ModelSnapshot::new(&model, 2);
+        assert!(Arc::ptr_eq(
+            &snapshot.entities_arc(),
+            &snapshot2.entities_arc()
+        ));
+    }
+
+    #[test]
+    fn test_snapshot_isolation_after_mutation() {
+        // Verify that mutations don't affect existing snapshots (COW)
+        let mut model = Model::new();
+        model.set_global("gold", 100.0f64);
+
+        let snapshot = ModelSnapshot::new(&model, 1);
+
+        // Mutate model - triggers copy-on-write
+        model.set_global("gold", 200.0f64);
+
+        // Snapshot should still have old value
+        assert_eq!(snapshot.get_global_number("gold"), Some(100.0));
+
+        // Model has new value
+        assert_eq!(
+            model.get_global("gold").and_then(|v| v.as_float()),
+            Some(200.0)
+        );
+
+        // Arcs should now be different (COW triggered)
+        assert!(!Arc::ptr_eq(&model.globals_arc(), &snapshot.globals_arc()));
+    }
+
+    #[test]
+    fn test_snapshot_is_send_sync() {
+        fn assert_send_sync<T: Send + Sync>() {}
+        assert_send_sync::<ModelSnapshot>();
+    }
+
+    #[test]
+    fn test_snapshot_globals_iteration() {
+        let mut model = Model::new();
+        model.set_global("gold", 100.0f64);
+        model.set_global("silver", 50.0f64);
+
+        let snapshot = ModelSnapshot::new(&model, 1);
+
+        let keys: Vec<_> = snapshot.globals_iter().map(|(k, _)| k.as_str()).collect();
+        assert!(keys.contains(&"gold"));
+        assert!(keys.contains(&"silver"));
     }
 }

--- a/crates/pulsive-netcode/src/interpolation.rs
+++ b/crates/pulsive-netcode/src/interpolation.rs
@@ -83,11 +83,11 @@ impl Interpolator {
         let alpha_f64 = alpha as f64;
 
         // Interpolate entity properties
-        for entity in result.entities.iter_mut() {
+        for entity in result.entities_mut().iter_mut() {
             let entity_id = entity.id;
 
             // Try to find corresponding entity in previous state
-            if let Some(prev_entity) = prev.entities.get(entity_id) {
+            if let Some(prev_entity) = prev.entities().get(entity_id) {
                 // Interpolate numeric properties
                 for (key, curr_value) in entity.properties.iter_mut() {
                     if let Some(prev_value) = prev_entity.get(key) {
@@ -98,8 +98,8 @@ impl Interpolator {
         }
 
         // Interpolate global properties
-        for (key, curr_value) in result.globals.iter_mut() {
-            if let Some(prev_value) = prev.globals.get(key) {
+        for (key, curr_value) in result.globals_mut().iter_mut() {
+            if let Some(prev_value) = prev.globals().get(key) {
                 *curr_value = Self::interpolate_value(prev_value, curr_value, alpha_f64);
             }
         }

--- a/crates/pulsive-netcode/src/prediction.rs
+++ b/crates/pulsive-netcode/src/prediction.rs
@@ -155,7 +155,7 @@ impl<H: StateHistory> PredictionEngine<H> {
         }
 
         // Compare globals (simplified)
-        if a.globals.len() != b.globals.len() {
+        if a.globals().len() != b.globals().len() {
             return false;
         }
 

--- a/crates/pulsive-netcode/src/reconciliation.rs
+++ b/crates/pulsive-netcode/src/reconciliation.rs
@@ -111,18 +111,18 @@ pub mod compare {
         }
 
         // Compare globals
-        if !maps_equal(&a.globals, &b.globals) {
+        if !maps_equal(a.globals(), b.globals()) {
             return false;
         }
 
         // Compare entity count
-        if a.entities.len() != b.entities.len() {
+        if a.entities().len() != b.entities().len() {
             return false;
         }
 
         // Compare each entity
-        for entity_a in a.entities.iter() {
-            match b.entities.get(entity_a.id) {
+        for entity_a in a.entities().iter() {
+            match b.entities().get(entity_a.id) {
                 Some(entity_b) => {
                     if entity_a.kind != entity_b.kind {
                         return false;
@@ -180,7 +180,7 @@ pub mod compare {
         model.current_tick().hash(&mut hasher);
 
         // Hash globals (sorted for consistency)
-        let mut globals: Vec<_> = model.globals.iter().collect();
+        let mut globals: Vec<_> = model.globals().iter().collect();
         globals.sort_by_key(|(k, _)| *k);
         for (key, value) in globals {
             key.hash(&mut hasher);
@@ -189,7 +189,7 @@ pub mod compare {
         }
 
         // Hash entity count
-        model.entities.len().hash(&mut hasher);
+        model.entities().len().hash(&mut hasher);
 
         hasher.finish()
     }

--- a/docs/index.md
+++ b/docs/index.md
@@ -74,7 +74,7 @@ fn main() {
     let mut runtime = Runtime::new();
     
     // Create an entity
-    let entity = model.entities.create("sensor");
+    let entity = model.entities_mut().create("sensor");
     entity.set("temperature", 22.5);
     entity.set("location", "room_1");
     

--- a/examples/http_server/src/main.rs
+++ b/examples/http_server/src/main.rs
@@ -136,7 +136,7 @@ impl ServerState {
         let mut model = Model::new();
 
         // Create server entity to track stats
-        let server_entity = model.entities.create("http_server");
+        let server_entity = model.entities_mut().create("http_server");
         server_entity.set("total_requests", Value::Int(0));
         server_entity.set("cache_hits", Value::Int(0));
         server_entity.set("cache_misses", Value::Int(0));
@@ -153,7 +153,7 @@ impl ServerState {
         let mut backend_entities = HashMap::new();
         for upstream in &config.upstreams {
             for server in &upstream.servers {
-                let backend = model.entities.create("backend");
+                let backend = model.entities_mut().create("backend");
                 backend.set("address", Value::String(server.address.clone()));
                 backend.set("upstream", Value::String(upstream.name.clone()));
                 backend.set("weight", Value::Int(server.weight as i64));
@@ -324,7 +324,7 @@ impl ServerState {
     /// Get current stats from the model
     async fn get_stats(&self) -> ServerStats {
         let model = self.model.read().await;
-        if let Some(entity) = model.entities.get(self.server_entity_id) {
+        if let Some(entity) = model.entities().get(self.server_entity_id) {
             ServerStats {
                 total_requests: entity.get_number("total_requests").unwrap_or(0.0) as u64,
                 cache_hits: entity.get_number("cache_hits").unwrap_or(0.0) as u64,

--- a/examples/simple_economy/src/main.rs
+++ b/examples/simple_economy/src/main.rs
@@ -20,14 +20,14 @@ fn main() {
     model.time = pulsive_core::Clock::with_start_date(1444, 11, 11);
 
     // Create two nations
-    let france = model.entities.create("nation");
+    let france = model.entities_mut().create("nation");
     france.set("name", "France");
     france.set("gold", 100.0f64);
     france.set("income", 10.0f64);
     france.set("expenses", 8.0f64);
     let france_id = france.id;
 
-    let england = model.entities.create("nation");
+    let england = model.entities_mut().create("nation");
     england.set("name", "England");
     england.set("gold", 80.0f64);
     england.set("income", 12.0f64);
@@ -76,8 +76,8 @@ fn main() {
         let _result = runtime.tick(&mut model);
 
         let date = model.time.current_date();
-        let france = model.entities.get(france_id).unwrap();
-        let england = model.entities.get(england_id).unwrap();
+        let france = model.entities().get(france_id).unwrap();
+        let england = model.entities().get(england_id).unwrap();
 
         println!(
             "Tick {} ({}): France: {:.1} gold, England: {:.1} gold",
@@ -97,7 +97,7 @@ fn main() {
     runtime.send(msg);
     runtime.process_queue(&mut model);
 
-    let france = model.entities.get(france_id).unwrap();
+    let france = model.entities().get(france_id).unwrap();
     println!(
         "After bonus: France now has {:.1} gold",
         france.get_number("gold").unwrap_or(0.0),
@@ -110,8 +110,8 @@ fn main() {
         runtime.tick(&mut model);
 
         let date = model.time.current_date();
-        let france = model.entities.get(france_id).unwrap();
-        let england = model.entities.get(england_id).unwrap();
+        let france = model.entities().get(france_id).unwrap();
+        let england = model.entities().get(england_id).unwrap();
 
         println!(
             "Tick {} ({}): France: {:.1} gold, England: {:.1} gold",

--- a/examples/typing_game/src/main.rs
+++ b/examples/typing_game/src/main.rs
@@ -91,7 +91,7 @@ fn run_game(
     model.set_global("rounds_completed", 0i64);
 
     // Create the round entity
-    let round = model.entities.create("round");
+    let round = model.entities_mut().create("round");
     round.set("sentence", "");
     round.set("typed_index", 0i64);
     round.set("round_score", 0i64);
@@ -219,7 +219,7 @@ fn run_game(
                 runtime.process_queue(&mut model);
 
                 // Check for timeout
-                let round_entity = model.entities.get(round_id).unwrap();
+                let round_entity = model.entities().get(round_id).unwrap();
                 let time_remaining =
                     round_entity.get_number("time_remaining_ms").unwrap_or(0.0) as i64;
                 if time_remaining <= 0 {
@@ -233,7 +233,7 @@ fn run_game(
             render_game_state(stdout, &model, round_id, sentence)?;
 
             // Check for round end
-            let round_entity = model.entities.get(round_id).unwrap();
+            let round_entity = model.entities().get(round_id).unwrap();
             let completed = round_entity
                 .get("completed")
                 .and_then(|v| v.as_bool())
@@ -284,7 +284,7 @@ fn run_game(
 }
 
 fn start_round(model: &mut Model, round_id: pulsive_core::EntityId, sentence: &str) {
-    let round = model.entities.get_mut(round_id).unwrap();
+    let round = model.entities_mut().get_mut(round_id).unwrap();
     round.set("sentence", sentence.to_string());
     round.set("typed_index", 0i64);
     round.set("round_score", 0i64);
@@ -300,7 +300,7 @@ fn handle_key_press(
     typed_char: char,
     sentence: &str,
 ) {
-    let round = model.entities.get(round_id).unwrap();
+    let round = model.entities().get(round_id).unwrap();
     let typed_index = round.get_number("typed_index").unwrap_or(0.0) as usize;
 
     // Check if the typed character matches
@@ -312,7 +312,7 @@ fn handle_key_press(
             runtime.process_queue(model);
 
             // Check if sentence is complete
-            let round = model.entities.get(round_id).unwrap();
+            let round = model.entities().get(round_id).unwrap();
             let new_index = round.get_number("typed_index").unwrap_or(0.0) as usize;
             if new_index >= sentence.len() {
                 let msg = Msg::event("round_complete", EntityRef::Entity(round_id), 0);
@@ -325,7 +325,7 @@ fn handle_key_press(
 }
 
 fn handle_backspace(model: &mut Model, round_id: pulsive_core::EntityId) {
-    let round = model.entities.get_mut(round_id).unwrap();
+    let round = model.entities_mut().get_mut(round_id).unwrap();
     let typed_index = round.get_number("typed_index").unwrap_or(0.0) as i64;
     if typed_index > 0 {
         round.set("typed_index", typed_index - 1);
@@ -383,7 +383,7 @@ fn render_game_state(
     round_id: pulsive_core::EntityId,
     sentence: &str,
 ) -> Result<(), Box<dyn std::error::Error>> {
-    let round = model.entities.get(round_id).unwrap();
+    let round = model.entities().get(round_id).unwrap();
     let typed_index = round.get_number("typed_index").unwrap_or(0.0) as usize;
     let round_score = round.get_number("round_score").unwrap_or(0.0) as i64;
     let time_remaining = round.get_number("time_remaining_ms").unwrap_or(0.0) as i64;
@@ -513,7 +513,7 @@ fn render_round_result(
     sentence: &str,
     completed: bool,
 ) -> Result<(), Box<dyn std::error::Error>> {
-    let round = model.entities.get(round_id).unwrap();
+    let round = model.entities().get(round_id).unwrap();
     let round_score = round.get_number("round_score").unwrap_or(0.0) as i64;
     let typed_index = round.get_number("typed_index").unwrap_or(0.0) as usize;
 


### PR DESCRIPTION
## Summary

Implement snapshot generation and WriteSet commit functionality for parallel execution orchestration.

## ModelSnapshot (Arc-based sharing)

- Arc-wrapped entities and globals for efficient sharing
- Read methods: `get_entity`, `get_global`, `entities_by_kind`, etc.
- Thread-safe: `Send + Sync` for parallel core access
- Immutable: snapshot remains unchanged after creation

## Commit API

- `commit()`: Apply single WriteSet with version tracking
- `commit_batch()`: Commit multiple WriteSets with conflict resolution
- `has_conflicts()`: Check for conflicts without committing
- `CommitResult`: Version, spawned/destroyed entities, conflicts resolved

## Integration

- Uses existing conflict detection/resolution from #24/#25
- Integrates with `apply()` for atomic WriteSet application
- Fast path for single WriteSet (no conflict detection)

## Tests

- 17 new tests for commit functionality
- 11 tests for snapshot read methods and immutability
- Arc sharing verification tests
- Thread safety compile-time checks

## Acceptance Criteria

- [x] Snapshots are truly immutable
- [x] Multiple cores can read same snapshot concurrently (Send + Sync)
- [x] Commits are atomic
- [x] WriteSet format from pulsive-core is reused

Closes #23